### PR TITLE
Fix failing mediation protocol after the connection to a mediator

### DIFF
--- a/AriesFramework/AriesFramework/agent/MessageSender.swift
+++ b/AriesFramework/AriesFramework/agent/MessageSender.swift
@@ -90,8 +90,7 @@ public class MessageSender {
             routingKeys: [],
             senderKey: senderKey)
 
-        // returnRoute makes acapy agent blocked on AATH
-        if agent.agentConfig.agentEndpoints == nil {
+        if message.transport == nil && message.requestResponse() {
             message.transport = TransportDecorator(returnRoute: "all")
         }
 

--- a/AriesFramework/AriesFramework/routing/MediationRecipient.swift
+++ b/AriesFramework/AriesFramework/routing/MediationRecipient.swift
@@ -48,7 +48,7 @@ class MediationRecipient {
         if let connection = await agent.connectionService.findByInvitationKey(recipientKey), connection.isReady() {
             try await requestMediationIfNecessry(connection: connection)
         } else {
-            let connection = try await agent.connectionService.processInvitation(invitation,
+            var connection = try await agent.connectionService.processInvitation(invitation,
                 outOfBandInvitation: outOfBandInvitation, routing: self.getRouting(), autoAcceptConnection: true)
             let message = try await agent.connectionService.createRequest(connectionId: connection.id)
             try await agent.messageSender.send(message: message)
@@ -59,6 +59,9 @@ class MediationRecipient {
                     throw AriesFrameworkError.frameworkError("Connection to the mediator timed out.")
                 }
             }
+
+            // Update connection record after the connection protocol.
+            connection = try await agent.connectionRepository.getById(connection.id)
             try await requestMediationIfNecessry(connection: connection)
         }
     }


### PR DESCRIPTION
## Checklist

- [x] I have run swiftlint
- [x] I have run AriesFrameworkTests
- [x] I have run AllTests

## Description

`AgentTest.testMediatorConnect()` fails for two reasons:
- trust-ping hangs after the connection response. ACA-Py mediator does not respond to a trust-ping with return-route:all.
- Agent cannot send mediation-request using the connection record created with the invitation. The recipient key of the mediator may change as the connection protocol progress.

So, I changed two things:
- Reference `message.requestResponse()` before setting transport decorator.
- Update the connection record before starting the mediation protocol.
