### PR TITLE
Try to fix the error of ACA-py agent not accepting OOB response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 Pods
 node_modules
+.vscode


### PR DESCRIPTION
## Checklist

- [x] I have run swiftlint
- [x] I have run AriesFrameworkTests
- [x] I have run AllTests

## Description

Try to fix issue #12
[OOB RFC](https://github.com/hyperledger/aries-rfcs/blob/main/features/0434-outofband/README.md#correlating-responses-to-out-of-band-messages) requires setting parent thread id for the response message of out-of-band invitation.