### PR TITLE
testing: Prevent failed tests from affecting other tests

### DIFF
--- a/AriesFramework/AriesFrameworkTests/TestHelper.swift
+++ b/AriesFramework/AriesFrameworkTests/TestHelper.swift
@@ -152,7 +152,7 @@ class TestHelper {
         return (received.theirDid == connection.did && received.theirKey() == connection.verkey)
     }
 
-    static func setupCredentialTests() async throws -> (Agent, Agent, String, ConnectionRecord, ConnectionRecord) {
+    static func setupCredentialTests() async throws -> (Agent, Agent, ConnectionRecord, ConnectionRecord) {
         let faberConfig = try TestHelper.getBaseConfig(name: "faber", useLedgerSerivce: true)
         let aliceConfig = try TestHelper.getBaseConfig(name: "alice", useLedgerSerivce: true)
 
@@ -165,10 +165,9 @@ class TestHelper {
         try await faberAgent.initialize()
         try await aliceAgent.initialize()
 
-        let credDefId = try await prepareForIssuance(faberAgent, ["name", "age"])
         let (faberConnection, aliceConnection) = try await makeConnection(faberAgent, aliceAgent)
 
-        return (faberAgent, aliceAgent, credDefId, faberConnection, aliceConnection)
+        return (faberAgent, aliceAgent, faberConnection, aliceConnection)
     }
 
     static func prepareForIssuance(_ agent: Agent, _ attributes: [String]) async throws -> String {

--- a/AriesFramework/AriesFrameworkTests/credentials/CredentialsTest.swift
+++ b/AriesFramework/AriesFrameworkTests/credentials/CredentialsTest.swift
@@ -18,7 +18,8 @@ class CredentialsTest: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
 
-        (faberAgent, aliceAgent, credDefId, faberConnection, aliceConnection) = try await TestHelper.setupCredentialTests()
+        (faberAgent, aliceAgent, faberConnection, aliceConnection) = try await TestHelper.setupCredentialTests()
+        credDefId = try await TestHelper.prepareForIssuance(faberAgent, ["name", "age"])
     }
 
     override func tearDown() async throws {

--- a/AriesFramework/AriesFrameworkTests/proofs/ProofsTest.swift
+++ b/AriesFramework/AriesFrameworkTests/proofs/ProofsTest.swift
@@ -16,7 +16,8 @@ class ProofsTest: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
 
-        (faberAgent, aliceAgent, credDefId, faberConnection, aliceConnection) = try await TestHelper.setupCredentialTests()
+        (faberAgent, aliceAgent, faberConnection, aliceConnection) = try await TestHelper.setupCredentialTests()
+        credDefId = try await TestHelper.prepareForIssuance(faberAgent, ["name", "age"])
     }
 
     override func tearDown() async throws {


### PR DESCRIPTION
## Checklist

- [x] I have run swiftlint
- [x] I have run AriesFrameworkTests
- [x] I have run AllTests

## Description

`TestHelper.prepareForIssuance()` fails from time to time when creating a schema throwing IndyError 309.
Move this function out of the agent initialization code to prevent it from affecting other tests.