### PR TITLE
Remove direct dependency on indy from sample app.

### DIFF
--- a/AriesFramework/AriesFramework/agent/Agent.swift
+++ b/AriesFramework/AriesFramework/agent/Agent.swift
@@ -3,6 +3,11 @@ import Foundation
 import Indy
 
 public class Agent {
+
+    public class func generateKey(forConfig: String = "{}") async throws -> String? {
+        return try await IndyWallet.generateKey(forConfig: forConfig)
+    }
+
     public var agentConfig: AgentConfig
     public var agentDelegate: AgentDelegate?
 
@@ -126,5 +131,9 @@ public class Agent {
     */
     public func setOutboundTransport(_ outboundTransport: OutboundTransport) {
         self.messageSender.setOutboundTransport(outboundTransport)
+    }
+
+    public func proverGetCredentials(forFilter: String = "{}") async throws -> String? {
+        return try await IndyAnoncreds.proverGetCredentials(forFilter: forFilter, walletHandle: wallet.handle!)
     }
 }

--- a/Sample/Podfile
+++ b/Sample/Podfile
@@ -1,5 +1,4 @@
 source 'https://github.com/CocoaPods/Specs.git'
-source 'https://github.com/naver/indy-sdk.git'
 platform :ios, '15.0'
 
 target 'wallet-app-ios' do

--- a/Sample/wallet-app-ios/CredentialListView.swift
+++ b/Sample/wallet-app-ios/CredentialListView.swift
@@ -4,7 +4,6 @@
 //
 
 import SwiftUI
-import Indy
 
 class CredentialList: ObservableObject {
     @Published var list: [Credential] = []
@@ -34,7 +33,7 @@ struct CredentialListView: View {
             .listStyle(.plain)
             .navigationTitle("Credential List")
             .task {
-                if let credentialsJson = try! await IndyAnoncreds.proverGetCredentials(forFilter: "{}", walletHandle: agent!.wallet.handle!) {
+                if let credentialsJson = try! await agent!.proverGetCredentials(forFilter: "{}") {
                     self.credentials.list = try! JSONDecoder().decode([Credential].self, from: credentialsJson.data(using: .utf8)!)
                 }
             }

--- a/Sample/wallet-app-ios/WalletOpener.swift
+++ b/Sample/wallet-app-ios/WalletOpener.swift
@@ -4,7 +4,6 @@
 //
 
 import SwiftUI
-import Indy
 import AriesFramework
 
 final class WalletState: ObservableObject {
@@ -20,7 +19,7 @@ class WalletOpener : ObservableObject {
         var key = userDefaults.value(forKey:"walletKey") as? String
         if (key == nil) {
             do {
-                key = try await IndyWallet.generateKey(forConfig: nil)
+                key = try await Agent.generateKey()
                 userDefaults.set(key, forKey: "walletKey")
             } catch {
                 if let err = error as NSError? {


### PR DESCRIPTION
## Checklist

- [V] I have run swiftlint
- [V] I have run AriesFrameworkTests
- [V] I have run AllTests

## Description

I'm not sure it's a good structure to pass these functions over to the Agent. However, my opinion is that at least the Sample app should not have a direct reference to Indy, and it would be better that the Agent object function as a **façade** that hides the specific details of Indy/Aries.