### PR TITLE
enable AgentConfig codable.

### DIFF
--- a/AriesFramework/AriesFramework/agent/AgentConfig.swift
+++ b/AriesFramework/AriesFramework/agent/AgentConfig.swift
@@ -3,7 +3,7 @@ import Foundation
 
 let DID_COMM_TRANSPORT_QUEUE = "didcomm:transport/queue"
 
-public struct AgentConfig {
+public struct AgentConfig: Codable {
     public init(
         walletId: String = "AFSDefaultWallet",
         walletKey: String,

--- a/AriesFramework/AriesFramework/routing/MediatorPickupStrategy.swift
+++ b/AriesFramework/AriesFramework/routing/MediatorPickupStrategy.swift
@@ -1,7 +1,7 @@
 
 import Foundation
 
-public enum MediatorPickupStrategy: String {
+public enum MediatorPickupStrategy: String, Codable {
     /// Pickup strategy used by AFJ
     case PickUpV1
     /// Pickup strategy used by ACA-Py


### PR DESCRIPTION
## Checklist

- [x] I have run AriesFrameworkTests
- [x] I have run AllTests

## Description
 
I think it is more convenient if AgentConfig is codable because it is possible save and load all the settings in a single operation and a single storage.