### PR TITLE
check application document directory instead of checking plist

### DIFF
--- a/AriesFramework/AriesFramework/ledger/LedgerService.swift
+++ b/AriesFramework/AriesFramework/ledger/LedgerService.swift
@@ -39,7 +39,6 @@ public class LedgerService {
 
         try await IndyPool.setProtocolVersion(2)
         let poolConfig = ["genesis_txn": agent.agentConfig.genesisPath].toString()
-        print(poolConfig)
         if !poolExists() {
             do {
                 try await IndyPool.createPoolLedgerConfig(withPoolName: agent.agentConfig.poolName, poolConfig: poolConfig)


### PR DESCRIPTION
## Checklist

- [x] I have run AriesFrameworkTests
- [x] I have run AllTests

## Description

Checking the actual existence of the file may be a better approach than relying on UserDefault to determine the existence of the pool. 