### PR TITLE
expose credential preview attribute constructor

### DIFF
--- a/AriesFramework/AriesFramework/credentials/models/CredentialPreview.swift
+++ b/AriesFramework/AriesFramework/credentials/models/CredentialPreview.swift
@@ -17,7 +17,7 @@ public struct CredentialPreview: Codable {
 
     public static func fromDictionary(_ dic: [String: String]) -> CredentialPreview {
         let attributes = dic.map { (key, value) -> CredentialPreviewAttribute in
-            return CredentialPreviewAttribute(name: key, mimeType: "text/plain", value: value)
+            return CredentialPreviewAttribute(name: key, value: value)
         }
         return CredentialPreview(attributes: attributes)
     }

--- a/AriesFramework/AriesFramework/credentials/models/CredentialPreviewAttribute.swift
+++ b/AriesFramework/AriesFramework/credentials/models/CredentialPreviewAttribute.swift
@@ -3,8 +3,14 @@ import Foundation
 
 public struct CredentialPreviewAttribute {
     public var name: String
-    public var mimeType: String?
+    public var mimeType: String
     public var value: String
+
+    public init(name: String, value: String, mimeType: String = "text/plain") {
+        self.mimeType = mimeType
+        self.name = name
+        self.value = value
+    }
 }
 
 extension CredentialPreviewAttribute: Codable {


### PR DESCRIPTION
# Checklist

- [x] have run AriesFrameworkTests
- [x]  I have run AllTests

# Description

expose credential preview attribute constructor in public and set mime type as optional with default value (text/plain).