### PR TITLE
ci: Fix workflow error - Change macos runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
           args: --strict
 
   RunTests:
-    runs-on: macos-latest
+    runs-on: macos-12
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Macos runner version change causes cocoapods version mismatch. So, Fix it to macos-12.