### PR TITLE
Delete mediation record if it's not ready

### DIFF
--- a/AriesFramework/AriesFramework/routing/MediationRecipient.swift
+++ b/AriesFramework/AriesFramework/routing/MediationRecipient.swift
@@ -68,10 +68,14 @@ class MediationRecipient {
     }
 
     func requestMediationIfNecessry(connection: ConnectionRecord) async throws {
-        if let mediationRecord = try await repository.getDefault(), mediationRecord.isReady() {
-            try await initiateMessagePickup(mediator: mediationRecord)
-            agent.setInitialized()
-            return
+        if let mediationRecord = try await repository.getDefault() {
+            if mediationRecord.isReady() {
+                try await initiateMessagePickup(mediator: mediationRecord)
+                agent.setInitialized()
+                return
+            }
+
+            try await repository.delete(mediationRecord)
         }
 
         // If mediation request has not been done yet, start it.


### PR DESCRIPTION
Fix a bug introduced by the previous PR #59 
We have to delete the old mediation record in both cases:
1. when the mediatorConnectionsInvite has changed
2. when the mediation status is not ready (mediation protocol started but not completed)