### PR TITLE
Fix offline message pickup

### DIFF
--- a/AriesFramework/AriesFramework/agent/MessageSender.swift
+++ b/AriesFramework/AriesFramework/agent/MessageSender.swift
@@ -37,7 +37,7 @@ public class MessageSender {
             agentMessage.replaceNewDidCommPrefixWithLegacyDidSov()
         }
 
-        if agentMessage.transport == nil && agentMessage.requestResponse() {
+        if agentMessage.transport == nil {
             agentMessage.transport = TransportDecorator(returnRoute: "all")
         }
 

--- a/AriesFramework/AriesFramework/routing/MediationRecipient.swift
+++ b/AriesFramework/AriesFramework/routing/MediationRecipient.swift
@@ -120,7 +120,7 @@ class MediationRecipient {
             let message = OutboundMessage(payload: BatchPickupMessage(batchSize: 10), connection: mediatorConnection)
             try await agent.messageSender.send(message: message)
         } else if agent.agentConfig.mediatorPickupStrategy == .Implicit {
-            let message = OutboundMessage(payload: TrustPingMessage(comment: "pickup", responseRequested: true), connection: mediatorConnection)
+            let message = OutboundMessage(payload: TrustPingMessage(comment: "pickup", responseRequested: false), connection: mediatorConnection)
             try await agent.messageSender.send(message: message, endpointPrefix: "ws")
         } else {
             throw AriesFrameworkError.frameworkError("Unsupported mediator pickup strategy: \(agent.agentConfig.mediatorPickupStrategy)")


### PR DESCRIPTION
`responseRequested` should be false to pickup messages received while the agent is offline.
See https://github.com/hyperledger/aries-framework-kotlin/pull/10