### PR TITLE
Change WebSocket dependency to a stable one

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/bhsw/concurrent-ws",
       "state" : {
-        "branch" : "f94666f",
-        "revision" : "f94666f7ac4a782eaf2888e48dcd0ca65ea7d435"
+        "revision" : "f94666f7ac4a782eaf2888e48dcd0ca65ea7d435",
+        "version" : "0.5.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/hyperledger/aries-uniffi-wrappers", exact: "0.1.0"),
-        .package(url: "https://github.com/bhsw/concurrent-ws", revision: "f94666f"),
+        .package(url: "https://github.com/bhsw/concurrent-ws", exact: "0.5.0"),
         .package(url: "https://github.com/JohnSundell/CollectionConcurrencyKit", exact: "0.2.0"),
         .package(url: "https://github.com/keefertaylor/Base58Swift", exact: "2.1.7"),
         .package(url: "https://github.com/thecatalinstan/Criollo", exact: "1.1.0")


### PR DESCRIPTION
Revision dependency only works in dev mode. We must use a tag for dependencies.