### PR TITLE
Use AsyncSemaphore

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -64,6 +64,15 @@
       }
     },
     {
+      "identity" : "semaphore",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/groue/Semaphore",
+      "state" : {
+        "revision" : "f1c4a0acabeb591068dea6cffdd39660b86dec28",
+        "version" : "0.0.8"
+      }
+    },
+    {
       "identity" : "siphash",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/attaswift/SipHash",

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,8 @@ let package = Package(
         .package(url: "https://github.com/bhsw/concurrent-ws", exact: "0.5.0"),
         .package(url: "https://github.com/JohnSundell/CollectionConcurrencyKit", exact: "0.2.0"),
         .package(url: "https://github.com/keefertaylor/Base58Swift", exact: "2.1.7"),
-        .package(url: "https://github.com/thecatalinstan/Criollo", exact: "1.1.0")
+        .package(url: "https://github.com/thecatalinstan/Criollo", exact: "1.1.0"),
+        .package(url: "https://github.com/groue/Semaphore", exact: "0.0.8")
     ],
     targets: [
         .target(
@@ -28,7 +29,8 @@ let package = Package(
                 .product(name: "IndyVdr", package: "aries-uniffi-wrappers"),
                 .product(name: "WebSockets", package: "concurrent-ws"),
                 "CollectionConcurrencyKit",
-                "Base58Swift"
+                "Base58Swift",
+                "Semaphore"
             ]),
         .testTarget(
             name: "AriesFrameworkTests",


### PR DESCRIPTION
Use AsyncSemaphore instead of NSLock.
Previous usage was not safe and this change removes build warning.

References:
- https://forums.swift.org/t/what-does-use-async-safe-scoped-locking-instead-even-mean/61029/8
- https://github.com/groue/Semaphore