### PR TITLE
Use AsyncSemaphore

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,5 +23,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Build
       run: swift build
+    - name: Install zmq
+      run: brew install zmq
     - name: Run tests
       run: swift test --skip AgentTest --skip CredentialsTest --skip LedgerServiceTest --skip OobTest --skip ProofsTest | xcpretty && exit ${PIPESTATUS[0]}

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -14,6 +14,7 @@ Run swiftlint at the root of the repo to check linting locally.
 - [BigInt](https://github.com/attaswift/BigInt): Provides big interger types used in the `CredentialValues` struct to encode credential attributes as big integers. Note that `BigInt` is in the dependency of `Base58Swift`.
 - [Base58Swift](https://github.com/keefertaylor/Base58Swift): Provides Base58 encoding/decoding used in `DIDParser` to handle [did:key](https://w3c-ccg.github.io/did-method-key/) in out-of-band invitation.
 - [Criollo](https://github.com/thecatalinstan/Criollo): Provides HTTP server that can be used in unit tests. We use this library to implement a backchannel for [AATH](https://github.com/hyperledger/aries-agent-test-harness).
+- [Semaphore](https://github.com/groue/Semaphore): AsyncSemaphore used in `WsOutboundTransport`. This can lock asynchrononous functions safely and hide compile warnings.
 
 ## Framework Internals
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -64,6 +64,15 @@
       }
     },
     {
+      "identity" : "semaphore",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/groue/Semaphore",
+      "state" : {
+        "revision" : "f1c4a0acabeb591068dea6cffdd39660b86dec28",
+        "version" : "0.0.8"
+      }
+    },
+    {
       "identity" : "siphash",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/attaswift/SipHash",

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,8 @@ let package = Package(
         .package(url: "https://github.com/bhsw/concurrent-ws", exact: "0.5.0"),
         .package(url: "https://github.com/JohnSundell/CollectionConcurrencyKit", exact: "0.2.0"),
         .package(url: "https://github.com/keefertaylor/Base58Swift", exact: "2.1.7"),
-        .package(url: "https://github.com/thecatalinstan/Criollo", exact: "1.1.0")
+        .package(url: "https://github.com/thecatalinstan/Criollo", exact: "1.1.0"),
+        .package(url: "https://github.com/groue/Semaphore", exact: "0.0.8")
     ],
     targets: [
         .target(
@@ -28,7 +29,8 @@ let package = Package(
                 .product(name: "IndyVdr", package: "aries-uniffi-wrappers"),
                 .product(name: "WebSockets", package: "concurrent-ws"),
                 "CollectionConcurrencyKit",
-                "Base58Swift"
+                "Base58Swift",
+                "Semaphore"
             ]),
         .testTarget(
             name: "AriesFrameworkTests",


### PR DESCRIPTION
Use AsyncSemaphore instead of NSLock.
Previous usage was not safe and this change removes build warning.

References:
- https://forums.swift.org/t/what-does-use-async-safe-scoped-locking-instead-even-mean/61029/8
- https://github.com/groue/Semaphore