### PR TITLE
Separate log messages in MessageReceiver

### DIFF
--- a/Sources/AriesFramework/agent/MessageReceiver.swift
+++ b/Sources/AriesFramework/agent/MessageReceiver.swift
@@ -22,7 +22,7 @@ public class MessageReceiver {
                                                        recipientVerkey: decryptedMessage.recipientKey)
             try await agent.dispatcher.dispatch(messageContext: messageContext)
         } catch {
-            logger.error("failed to receive message: \(error)")
+            logger.error("failed to receive encrypted message: \(error)")
         }
     }
 
@@ -36,7 +36,7 @@ public class MessageReceiver {
                                                        recipientVerkey: nil)
             try await agent.dispatcher.dispatch(messageContext: messageContext)
         } catch {
-            logger.error("failed to receive message: \(error)")
+            logger.error("failed to receive plaintext message: \(error)")
         }
     }
 


### PR DESCRIPTION
For better maintainability, I separate log messages between encrypted and plain text in the MessageReceiver.