### PR TITLE
Move comment and strengthen verification of test.

### DIFF
--- a/Sources/AriesFramework/proofs/ProofCommand.swift
+++ b/Sources/AriesFramework/proofs/ProofCommand.swift
@@ -106,7 +106,8 @@ public class ProofCommand {
     /**
      Create a ``RetrievedCredentials`` object. Given input proof request,
      use credentials in the wallet to build indy requested credentials object for proof creation.
-
+     Note: We do not filter out credentials that do not satisfy predicates.
+     
      - Parameters proofRecordId: the id of the proof request to get the matching credentials for.
      - Returns: ``RetrievedCredentials`` object.
     */

--- a/Tests/AriesFrameworkTests/proofs/ProofsTest.swift
+++ b/Tests/AriesFrameworkTests/proofs/ProofsTest.swift
@@ -162,8 +162,7 @@ class ProofsTest: XCTestCase {
         let retrievedCredentials = try await aliceAgent.proofs.getRequestedCredentialsForProofRequest(proofRecordId: aliceProofRecord.id)
 
         XCTAssertEqual(retrievedCredentials.requestedAttributes["name"]!.count, 1)
-        // We do not filter out credentials that do not satisfy predicates.
-        // XCTAssertEqual(retrievedCredentials.requestedPredicates["age"]!.count, 0)
+        XCTAssertEqual(retrievedCredentials.requestedPredicates["age"]!.count, 1)
 
         let requestedCredentials = try await aliceAgent.proofService.autoSelectCredentialsForProofRequest(retrievedCredentials: retrievedCredentials)
         do {


### PR DESCRIPTION
Move the position of the comment explaining the operation of the command from test code to source code and strengthen the verification of test code.