### PR TITLE
Implement DID Exchange Protocol

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,7 @@
 excluded:
   - .build
   - Sample
+  - Tests/javascript
 disabled_rules:
   - line_length
   - function_body_length

--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -109,3 +109,8 @@ $ yarn faber
 Then, get the invitation urls from the mediator and faber agent.
 Run `testDemoFaber()` with these urls and operate the faber agent to issue a credential.
 You can also use the Sample app to interact with the faber agent.
+
+You can see debug messages of faber agent by adding the following option to the agent config in `BaseAgent.ts`:
+```javascript
+    logger: new ConsoleLogger(LogLevel.debug),
+```

--- a/Package.resolved
+++ b/Package.resolved
@@ -64,6 +64,24 @@
       }
     },
     {
+      "identity" : "didcore-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/beatt83/didcore-swift.git",
+      "state" : {
+        "revision" : "3d62fc9ac4bf7d7be2958be057bb1f8f25fd15f5",
+        "version" : "1.1.0"
+      }
+    },
+    {
+      "identity" : "peerdid-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/beatt83/peerdid-swift",
+      "state" : {
+        "revision" : "36afa080c885ca7a06a6c50a37db2da865811267",
+        "version" : "2.1.0"
+      }
+    },
+    {
       "identity" : "semaphore",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/groue/Semaphore",
@@ -79,6 +97,24 @@
       "state" : {
         "revision" : "e325083424688055363bbfcb7f1a440d7d7a1bae",
         "version" : "1.2.2"
+      }
+    },
+    {
+      "identity" : "swift-bases",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-libp2p/swift-bases.git",
+      "state" : {
+        "revision" : "3cf27cf95d70248b0a1d99eee06cdf8b235241a8",
+        "version" : "0.0.3"
+      }
+    },
+    {
+      "identity" : "swift-multibase",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-libp2p/swift-multibase.git",
+      "state" : {
+        "revision" : "45f3cf2844477b9d211e1d3e793d0853134fd942",
+        "version" : "0.0.2"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/beatt83/didcore-swift.git",
       "state" : {
-        "revision" : "3d62fc9ac4bf7d7be2958be057bb1f8f25fd15f5",
-        "version" : "1.1.0"
+        "revision" : "2503b1690e11b16a0cdc8f492e370bbd9dcbe08b",
+        "version" : "2.0.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -73,15 +73,6 @@
       }
     },
     {
-      "identity" : "peerdid-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/beatt83/peerdid-swift",
-      "state" : {
-        "revision" : "36afa080c885ca7a06a6c50a37db2da865811267",
-        "version" : "2.1.0"
-      }
-    },
-    {
       "identity" : "semaphore",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/groue/Semaphore",

--- a/Package.resolved
+++ b/Package.resolved
@@ -73,6 +73,15 @@
       }
     },
     {
+      "identity" : "peerdid-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/beatt83/peerdid-swift",
+      "state" : {
+        "revision" : "4e82ff42aa2b53b2d361f482b607763d79ccfdbb",
+        "version" : "3.0.0"
+      }
+    },
+    {
       "identity" : "semaphore",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/groue/Semaphore",

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,8 @@ let package = Package(
         .package(url: "https://github.com/keefertaylor/Base58Swift", exact: "2.1.7"),
         .package(url: "https://github.com/thecatalinstan/Criollo", exact: "1.1.0"),
         .package(url: "https://github.com/groue/Semaphore", exact: "0.0.8"),
-        .package(url: "https://github.com/beatt83/peerdid-swift", exact: "2.1.0")
+        // .package(url: "https://github.com/beatt83/peerdid-swift", exact: "2.1.0")
+        .package(path: "../../fork/peerdid-swift")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .package(url: "https://github.com/thecatalinstan/Criollo", exact: "1.1.0"),
         .package(url: "https://github.com/groue/Semaphore", exact: "0.0.8"),
         // .package(url: "https://github.com/beatt83/peerdid-swift", exact: "2.1.0")
-        .package(path: "../../fork/peerdid-swift")
+        .package(path: "../../aries/peerdid-swift")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,9 @@ let package = Package(
         .package(url: "https://github.com/JohnSundell/CollectionConcurrencyKit", exact: "0.2.0"),
         .package(url: "https://github.com/keefertaylor/Base58Swift", exact: "2.1.7"),
         .package(url: "https://github.com/thecatalinstan/Criollo", exact: "1.1.0"),
-        .package(url: "https://github.com/groue/Semaphore", exact: "0.0.8")
+        .package(url: "https://github.com/groue/Semaphore", exact: "0.0.8"),
+//        .package(url: "https://github.com/beatt83/didcore-swift.git", exact: "1.1.0"),
+        .package(url: "https://github.com/beatt83/peerdid-swift", exact: "2.1.0")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -19,8 +19,7 @@ let package = Package(
         .package(url: "https://github.com/keefertaylor/Base58Swift", exact: "2.1.7"),
         .package(url: "https://github.com/thecatalinstan/Criollo", exact: "1.1.0"),
         .package(url: "https://github.com/groue/Semaphore", exact: "0.0.8"),
-        // .package(url: "https://github.com/beatt83/peerdid-swift", exact: "2.1.0")
-        .package(path: "../../aries/peerdid-swift")
+        .package(url: "https://github.com/beatt83/peerdid-swift", exact: "3.0.0")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,6 @@ let package = Package(
         .package(url: "https://github.com/keefertaylor/Base58Swift", exact: "2.1.7"),
         .package(url: "https://github.com/thecatalinstan/Criollo", exact: "1.1.0"),
         .package(url: "https://github.com/groue/Semaphore", exact: "0.0.8"),
-//        .package(url: "https://github.com/beatt83/didcore-swift.git", exact: "1.1.0"),
         .package(url: "https://github.com/beatt83/peerdid-swift", exact: "2.1.0")
     ],
     targets: [
@@ -30,6 +29,7 @@ let package = Package(
                 .product(name: "Askar", package: "aries-uniffi-wrappers"),
                 .product(name: "IndyVdr", package: "aries-uniffi-wrappers"),
                 .product(name: "WebSockets", package: "concurrent-ws"),
+                .product(name: "PeerDID", package: "peerdid-swift"),
                 "CollectionConcurrencyKit",
                 "Base58Swift",
                 "Semaphore"

--- a/Sources/AriesFramework/agent/Agent.swift
+++ b/Sources/AriesFramework/agent/Agent.swift
@@ -12,6 +12,7 @@ public class Agent {
     public var connectionRepository: ConnectionRepository!
     public var connectionService: ConnectionService!
     public var didExchangeService: DidExchangeService!
+    public var peerDIDService: PeerDIDService!
     var messageSender: MessageSender!
     var messageReceiver: MessageReceiver!
     public var dispatcher: Dispatcher!
@@ -44,6 +45,7 @@ public class Agent {
         self.connectionRepository = ConnectionRepository(agent: self)
         self.connectionService = ConnectionService(agent: self)
         self.didExchangeService = DidExchangeService(agent: self)
+        self.peerDIDService = PeerDIDService(agent: self)
         self.messageSender = MessageSender(agent: self)
         self.messageReceiver = MessageReceiver(agent: self)
         self.dispatcher = Dispatcher(agent: self)

--- a/Sources/AriesFramework/agent/Agent.swift
+++ b/Sources/AriesFramework/agent/Agent.swift
@@ -89,7 +89,7 @@ public class Agent {
             try await ledgerService.initialize()
         }
 
-        if let mediatorConnectionsInvite = agentConfig.mediatorConnectionsInvite, agentConfig.useMediator {
+        if let mediatorConnectionsInvite = agentConfig.mediatorConnectionsInvite {
             try await mediationRecipient.initialize(mediatorConnectionsInvite: mediatorConnectionsInvite)
         } else {
             setInitialized()

--- a/Sources/AriesFramework/agent/Agent.swift
+++ b/Sources/AriesFramework/agent/Agent.swift
@@ -11,6 +11,7 @@ public class Agent {
     var mediationRecipient: MediationRecipient!
     public var connectionRepository: ConnectionRepository!
     public var connectionService: ConnectionService!
+    public var didExchangeService: DidExchangeService!
     var messageSender: MessageSender!
     var messageReceiver: MessageReceiver!
     public var dispatcher: Dispatcher!
@@ -42,6 +43,7 @@ public class Agent {
         self.wallet = Wallet(agent: self)
         self.connectionRepository = ConnectionRepository(agent: self)
         self.connectionService = ConnectionService(agent: self)
+        self.didExchangeService = DidExchangeService(agent: self)
         self.messageSender = MessageSender(agent: self)
         self.messageReceiver = MessageReceiver(agent: self)
         self.dispatcher = Dispatcher(agent: self)

--- a/Sources/AriesFramework/agent/Agent.swift
+++ b/Sources/AriesFramework/agent/Agent.swift
@@ -89,7 +89,7 @@ public class Agent {
             try await ledgerService.initialize()
         }
 
-        if let mediatorConnectionsInvite = agentConfig.mediatorConnectionsInvite {
+        if let mediatorConnectionsInvite = agentConfig.mediatorConnectionsInvite, agentConfig.useMediator {
             try await mediationRecipient.initialize(mediatorConnectionsInvite: mediatorConnectionsInvite)
         } else {
             setInitialized()

--- a/Sources/AriesFramework/agent/AgentConfig.swift
+++ b/Sources/AriesFramework/agent/AgentConfig.swift
@@ -22,6 +22,7 @@ public struct AgentConfig: Codable {
         useLegacyDidSovPrefix: Bool = true,
         preferredHandshakeProtocol: HandshakeProtocol = .Connections,
         publicDidSeed: String? = nil,
+        useMediator: Bool = true,
         agentEndpoints: [String]? = nil) {
 
         self.walletId = walletId
@@ -41,6 +42,7 @@ public struct AgentConfig: Codable {
         self.useLegacyDidSovPrefix = useLegacyDidSovPrefix
         self.preferredHandshakeProtocol = preferredHandshakeProtocol
         self.publicDidSeed = publicDidSeed
+        self.useMediator = useMediator
         self.agentEndpoints = agentEndpoints
     }
 
@@ -84,6 +86,8 @@ public struct AgentConfig: Codable {
 
     /// The seed to use for the public did. The public did is used to register items on the ledger.
     public var publicDidSeed: String?
+    /// Whether to use the mediator when mediatorConnectionsInvite is set. Default is true.
+    public var useMediator: Bool
     /// The agent endpoints to use for testing.
     public var agentEndpoints: [String]?
     /// Whether to ignore revocation checks when creating a presentation. Default is false.

--- a/Sources/AriesFramework/agent/AgentConfig.swift
+++ b/Sources/AriesFramework/agent/AgentConfig.swift
@@ -22,7 +22,6 @@ public struct AgentConfig: Codable {
         useLegacyDidSovPrefix: Bool = true,
         preferredHandshakeProtocol: HandshakeProtocol = .Connections,
         publicDidSeed: String? = nil,
-        useMediator: Bool = true,
         agentEndpoints: [String]? = nil) {
 
         self.walletId = walletId
@@ -42,7 +41,6 @@ public struct AgentConfig: Codable {
         self.useLegacyDidSovPrefix = useLegacyDidSovPrefix
         self.preferredHandshakeProtocol = preferredHandshakeProtocol
         self.publicDidSeed = publicDidSeed
-        self.useMediator = useMediator
         self.agentEndpoints = agentEndpoints
     }
 
@@ -86,8 +84,6 @@ public struct AgentConfig: Codable {
 
     /// The seed to use for the public did. The public did is used to register items on the ledger.
     public var publicDidSeed: String?
-    /// Whether to use the mediator when mediatorConnectionsInvite is set. Default is true.
-    public var useMediator: Bool
     /// The agent endpoints to use for testing.
     public var agentEndpoints: [String]?
     /// Whether to ignore revocation checks when creating a presentation. Default is false.

--- a/Sources/AriesFramework/agent/AgentConfig.swift
+++ b/Sources/AriesFramework/agent/AgentConfig.swift
@@ -20,6 +20,7 @@ public struct AgentConfig: Codable {
         ignoreRevocationCheck: Bool = false,
         useLedgerService: Bool = true,
         useLegacyDidSovPrefix: Bool = true,
+        preferredHandshakeProtocol: HandshakeProtocol = .Connections,
         publicDidSeed: String? = nil,
         agentEndpoints: [String]? = nil) {
 
@@ -38,6 +39,7 @@ public struct AgentConfig: Codable {
         self.ignoreRevocationCheck = ignoreRevocationCheck
         self.useLedgerService = useLedgerService
         self.useLegacyDidSovPrefix = useLegacyDidSovPrefix
+        self.preferredHandshakeProtocol = preferredHandshakeProtocol
         self.publicDidSeed = publicDidSeed
         self.agentEndpoints = agentEndpoints
     }
@@ -75,6 +77,8 @@ public struct AgentConfig: Codable {
     public var useLedgerService: Bool
     /// Whether to use the legacy did sov prefix. Default is true.
     public var useLegacyDidSovPrefix: Bool
+    /// The preferred handshake protocol to use. Default is `.Connections`.
+    public var preferredHandshakeProtocol: HandshakeProtocol
 
     // For testing
 

--- a/Sources/AriesFramework/connection/ConnectionCommand.swift
+++ b/Sources/AriesFramework/connection/ConnectionCommand.swift
@@ -128,7 +128,9 @@ public class ConnectionCommand {
                 imageUrl: config?.imageUrl,
                 autoAcceptConnection: config?.autoAcceptConnection)
         } else {
-            throw AriesFrameworkError.frameworkError("Handshake protocol \(handshakeProtocol) not implemented")
+            message = try await agent.didExchangeService.createRequest(connectionId: connection.id,
+                label: config?.label,
+                autoAcceptConnection: config?.autoAcceptConnection)
         }
         try await agent.messageSender.send(message: message)
         return message.connection

--- a/Sources/AriesFramework/connection/ConnectionService.swift
+++ b/Sources/AriesFramework/connection/ConnectionService.swift
@@ -121,7 +121,7 @@ public class ConnectionService {
         return connectionRecord
     }
 
-    private func createConnection(
+    func createConnection(
         role: ConnectionRole,
         state: ConnectionState,
         invitation: ConnectionInvitationMessage? = nil,

--- a/Sources/AriesFramework/connection/DidExchangeService.swift
+++ b/Sources/AriesFramework/connection/DidExchangeService.swift
@@ -152,6 +152,7 @@ public class DidExchangeService {
         let didDoc = try agent.peerDIDService.parsePeerDID(message.did)
         connectionRecord.theirDid = didDoc.id
         connectionRecord.theirDidDoc = didDoc
+        // TODO: Verify the signature of message.didRotate attachment
 
         try await updateState(connectionRecord: &connectionRecord, newState: ConnectionState.Responded)
         return connectionRecord

--- a/Sources/AriesFramework/connection/DidExchangeService.swift
+++ b/Sources/AriesFramework/connection/DidExchangeService.swift
@@ -32,6 +32,7 @@ public class DidExchangeService {
         assert(connectionRecord.role == ConnectionRole.Invitee)
 
         let peerDid = try await agent.peerDIDService.createPeerDID(verkey: connectionRecord.verkey)
+        logger.debug("Created peer DID for a RequestMessage: \(peerDid)")
         let message = DidExchangeRequestMessage(label: label ?? agent.agentConfig.label, did: peerDid)
 
         if autoAcceptConnection != nil {

--- a/Sources/AriesFramework/connection/DidExchangeService.swift
+++ b/Sources/AriesFramework/connection/DidExchangeService.swift
@@ -69,8 +69,7 @@ public class DidExchangeService {
             outOfBandRecord = outOfBandRecords[0]
         }
 
-        // TODO: get rawDid and didDoc from message.did
-        let rawDid = ""
+        // TODO: get didDoc from message.did
         let didDoc = ""
 
         var connectionRecord = try await agent.connectionService.createConnection(
@@ -91,7 +90,7 @@ public class DidExchangeService {
         connectionRecord.theirDidDoc = didDoc
         connectionRecord.theirLabel = message.label
         connectionRecord.threadId = message.id
-        connectionRecord.theirDid = rawDid
+        connectionRecord.theirDid = didDoc.id
         connectionRecord.imageUrl = message.imageUrl
 
         if connectionRecord.theirKey() == nil {
@@ -153,11 +152,10 @@ public class DidExchangeService {
             throw AriesFrameworkError.frameworkError("Invalid or missing thread ID")
         }
 
-        // TODO: get rawDid and didDoc from message.did
-        let rawDid = ""
+        // TODO: get didDoc from message.did
         let didDoc = ""
 
-        connectionRecord.theirDid = rawDid
+        connectionRecord.theirDid = didDoc.id
         connectionRecord.theirDidDoc = didDoc
 
         try await updateState(connectionRecord: &connectionRecord, newState: ConnectionState.Responded)

--- a/Sources/AriesFramework/connection/DidExchangeService.swift
+++ b/Sources/AriesFramework/connection/DidExchangeService.swift
@@ -1,0 +1,206 @@
+
+import Foundation
+import os
+
+public class DidExchangeService {
+    let agent: Agent
+    let connectionRepository: ConnectionRepository
+    let connectionWaiter = AsyncWaiter()
+    let logger = Logger(subsystem: "AriesFramework", category: "DidExchangeService")
+
+    init(agent: Agent) {
+        self.agent = agent
+        self.connectionRepository = agent.connectionRepository
+    }
+
+    /**
+     Create a DID exchange request message for the connection with the specified connection id.
+
+     - Parameters:
+       - connectionId: the id of the connection for which to create a DID exchange request.
+       - label: the label to use for the DID exchange request.
+       - autoAcceptConnection: whether to automatically accept the DID exchange response.
+     - Returns: outbound message containing DID exchange request.
+    */
+    public func createRequest(
+        connectionId: String,
+        label: String? = nil,
+        autoAcceptConnection: Bool? = nil) async throws -> OutboundMessage {
+
+        var connectionRecord = try await self.connectionRepository.getById(connectionId)
+        assert(connectionRecord.state == ConnectionState.Invited)
+        assert(connectionRecord.role == ConnectionRole.Invitee)
+
+        // TODO: get peer did from connectionRecord.did
+        let peerDid = "did:peer:0z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+        let message = DidExchangeRequestMessage(label: label ?? agent.agentConfig.label, did: peerDid)
+
+        if autoAcceptConnection != nil {
+            connectionRecord.autoAcceptConnection = autoAcceptConnection
+        }
+        connectionRecord.threadId = message.id
+        try await updateState(connectionRecord: &connectionRecord, newState: ConnectionState.Requested)
+
+        return OutboundMessage(payload: message, connection: connectionRecord)
+    }
+
+    /**
+     Process a received DID exchange request message. This will not accept the DID exchange request
+     or send a DID exchange response message. It will only update the existing connection record
+     with all the new information from the DID exchange request message. Use ``createResponse(connectionId:)``
+     after calling this function to create a DID exchange response.
+
+     - Parameter messageContext: the message context containing the DID exchange request message.
+     - Returns: updated connection record.
+    */
+    public func processRequest(messageContext: InboundMessageContext) async throws -> ConnectionRecord {
+        let decoder = JSONDecoder()
+        let message = try decoder.decode(DidExchangeRequestMessage.self, from: Data(messageContext.plaintextMessage.utf8))
+
+        guard let recipientKey = messageContext.recipientVerkey, let senderKey = messageContext.senderVerkey else {
+            throw AriesFrameworkError.frameworkError("Unable to process connection request without senderVerkey or recipientVerkey")
+        }
+
+        var outOfBandRecord: OutOfBandRecord?
+        let outOfBandRecords = await agent.outOfBandService.findAllByInvitationKey(recipientKey)
+        if outOfBandRecords.isEmpty {
+            throw AriesFrameworkError.frameworkError("No out-of-band record or connection record found for invitation key: \(recipientKey)")
+        } else {
+            outOfBandRecord = outOfBandRecords[0]
+        }
+
+        // TODO: get rawDid and didDoc from message.did
+        let rawDid = ""
+        let didDoc = ""
+
+        var connectionRecord = try await agent.connectionService.createConnection(
+            role: .Inviter,
+            state: .Invited,
+            invitation: nil,
+            outOfBandInvitation: outOfBandRecord!.outOfBandInvitation,
+            alias: nil,
+            routing: agent.mediationRecipient.getRouting(),
+            theirLabel: message.label,
+            autoAcceptConnection: outOfBandRecord!.autoAcceptConnection,
+            multiUseInvitation: true,
+            imageUrl: message.imageUrl,
+            threadId: message.threadId)
+
+        try await self.connectionRepository.save(connectionRecord)
+
+        connectionRecord.theirDidDoc = didDoc
+        connectionRecord.theirLabel = message.label
+        connectionRecord.threadId = message.id
+        connectionRecord.theirDid = rawDid
+        connectionRecord.imageUrl = message.imageUrl
+
+        if connectionRecord.theirKey() == nil {
+            throw AriesFrameworkError.frameworkError("Connection with id \(connectionRecord!.id) has no recipient keys.")
+        }
+
+        try await updateState(connectionRecord: &connectionRecord, newState: .Requested)
+        return connectionRecord!
+    }
+
+    /**
+     Create a DID exchange response message for the connection with the specified connection id.
+
+     - Parameter connectionId: the id of the connection for which to create a DID exchange response.
+     - Returns: outbound message containing DID exchange response.
+    */
+    public func createResponse(connectionId: String) async throws -> OutboundMessage {
+        var connectionRecord = try await connectionRepository.getById(connectionId)
+        assert(connectionRecord.state == ConnectionState.Requested)
+        assert(connectionRecord.role == ConnectionRole.Inviter)
+        guard let threadId = connectionRecord.threadId else {
+            throw AriesFrameworkError.frameworkError("Connection record with id \(connectionRecord.id) has no thread id.")
+        }
+
+        // TODO: get peer did from connectionRecord.did
+        let peerDid = "did:peer:0z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+
+        let message = DidExchangeResponseMessage(threadId: threadId, did: peerDid)
+        message.thread = ThreadDecorator(threadId: threadId)
+
+        try await updateState(connectionRecord: &connectionRecord, newState: .Responded)
+
+        return OutboundMessage(payload: message, connection: connectionRecord)
+    }
+
+    /**
+     Process a received DID exchange response message. This will not accept the DID exchange response
+     or send a DID exchange complete message. It will only update the existing connection record
+     with all the new information from the DID exchange response message. Use ``createComplete(connectionId:)``
+     after calling this function to create a DID exchange complete message.
+
+     - Parameter messageContext: the message context containing a DID exchange response message.
+     - Returns: updated connection record.
+    */
+    public func processResponse(messageContext: InboundMessageContext) async throws -> ConnectionRecord {
+        let decoder = JSONDecoder()
+        let message = try decoder.decode(DidExchangeResponseMessage.self, from: Data(messageContext.plaintextMessage.utf8))
+
+        var connectionRecord: ConnectionRecord!
+        do {
+            connectionRecord = try await agent.connectionService.getByThreadId(message.threadId)
+        } catch {
+            throw AriesFrameworkError.frameworkError("Unable to process DID exchange response: connection for threadId: \(message.threadId) not found")
+        }
+        assert(connectionRecord.state == ConnectionState.Requested)
+        assert(connectionRecord.role == ConnectionRole.Invitee)
+
+        if message.thread != connectionRecord.threadId {
+            throw AriesFrameworkError.frameworkError("Invalid or missing thread ID")
+        }
+
+        // TODO: get rawDid and didDoc from message.did
+        let rawDid = ""
+        let didDoc = ""
+
+        connectionRecord.theirDid = rawDid
+        connectionRecord.theirDidDoc = didDoc
+
+        try await updateState(connectionRecord: &connectionRecord, newState: ConnectionState.Responded)
+        return connectionRecord
+    }
+
+    /**
+     Create a DID exchange complete message for the connection with the specified connection id.
+
+     - Parameter connectionId: the id of the connection for which to create a DID exchange complete message.
+     - Returns: outbound message containing a DID exchange complete message.
+    */
+    public func createComplete(connectionId: String) async throws -> OutboundMessage {
+        var connectionRecord = try await self.connectionRepository.getById(connectionId)
+        assert(connectionRecord.state == ConnectionState.Responded)
+
+        guard let threadId = connectionRecord.threadId else {
+            throw AriesFrameworkError.frameworkError("Connection record with id \(connectionRecord.id) has no thread id.")
+        }
+        guard let parentThreadId = connectionRecord.outOfBandInvitation?.id else {
+            throw AriesFrameworkError.frameworkError("Connection record with id \(connectionRecord.id) has no parent thread id.")
+        }
+
+        let message = DidExchangeCompleteMessage(threadId: threadId, parentThreadId: parentThreadId)
+        try await updateState(connectionRecord: &connectionRecord, newState: ConnectionState.Complete)
+
+        return OutboundMessage(payload: message, connection: connectionRecord)
+    }
+
+    func updateState(connectionRecord: inout ConnectionRecord, newState: ConnectionState) async throws {
+        connectionRecord.state = newState
+        try await self.connectionRepository.update(connectionRecord)
+        if newState == ConnectionState.Complete {
+            finishConnectionWaiter()
+        }
+        agent.agentDelegate?.onConnectionStateChanged(connectionRecord: connectionRecord)
+    }
+
+    func waitForConnection() async throws -> Bool {
+        return try await connectionWaiter.wait()
+    }
+
+    private func finishConnectionWaiter() {
+        connectionWaiter.finish()
+    }
+}

--- a/Sources/AriesFramework/connection/DidExchangeService.swift
+++ b/Sources/AriesFramework/connection/DidExchangeService.swift
@@ -38,6 +38,7 @@ public class DidExchangeService {
             connectionRecord.autoAcceptConnection = autoAcceptConnection
         }
         connectionRecord.threadId = message.id
+        connectionRecord.did = peerDid
         try await updateState(connectionRecord: &connectionRecord, newState: ConnectionState.Requested)
 
         return OutboundMessage(payload: message, connection: connectionRecord)
@@ -56,7 +57,7 @@ public class DidExchangeService {
         let decoder = JSONDecoder()
         let message = try decoder.decode(DidExchangeRequestMessage.self, from: Data(messageContext.plaintextMessage.utf8))
 
-        guard let recipientKey = messageContext.recipientVerkey, let senderKey = messageContext.senderVerkey else {
+        guard let recipientKey = messageContext.recipientVerkey, let _ = messageContext.senderVerkey else {
             throw AriesFrameworkError.frameworkError("Unable to process connection request without senderVerkey or recipientVerkey")
         }
 
@@ -112,6 +113,7 @@ public class DidExchangeService {
         }
 
         let peerDid = try await agent.peerDIDService.createPeerDID(verkey: connectionRecord.verkey)
+        connectionRecord.did = peerDid
 
         let message = DidExchangeResponseMessage(threadId: threadId, did: peerDid)
         message.thread = ThreadDecorator(threadId: threadId)

--- a/Sources/AriesFramework/connection/DidExchangeService.swift
+++ b/Sources/AriesFramework/connection/DidExchangeService.swift
@@ -58,8 +58,8 @@ public class DidExchangeService {
         let decoder = JSONDecoder()
         let message = try decoder.decode(DidExchangeRequestMessage.self, from: Data(messageContext.plaintextMessage.utf8))
 
-        guard let recipientKey = messageContext.recipientVerkey, let _ = messageContext.senderVerkey else {
-            throw AriesFrameworkError.frameworkError("Unable to process connection request without senderVerkey or recipientVerkey")
+        guard let recipientKey = messageContext.recipientVerkey else {
+            throw AriesFrameworkError.frameworkError("Unable to process connection request without recipientVerkey")
         }
 
         var outOfBandRecord: OutOfBandRecord?

--- a/Sources/AriesFramework/connection/PeerDIDService.swift
+++ b/Sources/AriesFramework/connection/PeerDIDService.swift
@@ -1,0 +1,12 @@
+
+import Foundation
+import PeerDID
+
+public class PeerDIDService {
+    let agent: Agent
+    let logger = Logger(subsystem: "AriesFramework", category: "PeerDIDService")
+
+    init(agent: Agent) {
+        self.agent = agent
+    }
+}

--- a/Sources/AriesFramework/connection/PeerDIDService.swift
+++ b/Sources/AriesFramework/connection/PeerDIDService.swift
@@ -1,6 +1,9 @@
 
 import Foundation
+import os
+import DIDCore
 import PeerDID
+import Base58Swift
 
 public class PeerDIDService {
     let agent: Agent
@@ -8,5 +11,58 @@ public class PeerDIDService {
 
     init(agent: Agent) {
         self.agent = agent
+    }
+
+    /**
+     Create a Peer DID for the given verkey. This use numAlgo 0 when mediator is not used,
+     otherwise it uses numAlgo 2.
+
+     - Parameter verkey: the verkey to use for the Peer DID.
+     - Returns: the Peer DID.
+    */
+    public func createPeerDID(verkey: String) async throws -> String {
+        logger.debug("Creating Peer DID for verkey: \(verkey)")
+        let verkey = Data(Base58.base58Decode(verkey)!)
+        if agent.agentConfig.mediatorConnectionsInvite == nil {
+            let material = try PeerDIDVerificationMaterial(
+                format: .base58,
+                key: verkey,
+                type: .authentication(.ed25519VerificationKey2018))
+            let did = try PeerDIDHelper.createAlgo0(key: material).string
+            logger.debug("Created Peer DID: \(did)")
+            return did
+        }
+        
+        let (endpoints, routingKeys) = try await agent.mediationRecipient.getRoutingInfo()
+        let didRoutingKeys = try DIDParser.ConvertVerkeysToDidKeys(verkeys: routingKeys)
+        let authKey = try PeerDIDVerificationMaterial(
+            format: .base58,
+            key: verkey,
+            type: .authentication(.ed25519VerificationKey2020))
+        let agreementKey = try PeerDIDVerificationMaterial(
+            format: .base58,
+            key: verkey,
+            type: .agreement(.x25519KeyAgreementKey2020))
+        let service = DIDDocument.Service(
+            id: "#IndyAgentService",
+            type: "DIDCommMessaging",
+            serviceEndpoint: AnyCodable(dictionaryLiteral: ("uri", endpoints[0]), ("routing_keys", didRoutingKeys)))
+        return try PeerDIDHelper.createAlgo2(
+            authenticationKeys: [authKey],
+            agreementKeys: [agreementKey],
+            services: [service]).string
+    }
+
+    /**
+     Parse a Peer DID into a DidDoc. Only numAlgo 0 and 2 are supported.
+     In case of numAlgo 2 DID, the routing keys should be did:key format.
+
+     - Parameter did: the Peer DID to parse.
+     - Returns: the parsed DID Document.
+    */
+    public func parsePeerDID(_ did: String) throws -> DidDoc {
+        logger.debug("Parsing Peer DID: \(did)")
+        let didDocument = try PeerDIDHelper.resolve(peerDIDStr: did)
+        return try DidDoc(from: didDocument)
     }
 }

--- a/Sources/AriesFramework/connection/PeerDIDService.swift
+++ b/Sources/AriesFramework/connection/PeerDIDService.swift
@@ -21,6 +21,8 @@ public class PeerDIDService {
     */
     public func createPeerDID(verkey: String) async throws -> String {
         logger.debug("Creating Peer DID for verkey: \(verkey)")
+        let didKey = try DIDParser.ConvertVerkeyToDidKey(verkey: verkey)
+        logger.debug("did:key for verkey: \(didKey)")
         let verkey = Data(Base58.base58Decode(verkey)!)
         
         let (endpoints, routingKeys) = try await agent.mediationRecipient.getRoutingInfo()
@@ -41,7 +43,7 @@ public class PeerDIDService {
             authenticationKeys: [authKey],
             agreementKeys: [agreementKey],
             services: [service],
-            recipientKeys: [[]])
+            recipientKeys: [[didKey]])
             .string
     }
 

--- a/Sources/AriesFramework/connection/PeerDIDService.swift
+++ b/Sources/AriesFramework/connection/PeerDIDService.swift
@@ -36,15 +36,17 @@ public class PeerDIDService {
             format: .base58,
             key: verkeyData,
             type: .agreement(.x25519KeyAgreementKey2019))
-        let service = DIDDocument.Service(
-            id: "#service-1",
-            type: DidCommService.type,
-            serviceEndpoint: AnyCodable(dictionaryLiteral: ("uri", endpoints[0]), ("routingKeys", didRoutingKeys)))
+        let service = [
+            "id": "#service-1",
+            "type": DidCommService.type,
+            "serviceEndpoint": endpoints[0],
+            "routingKeys": didRoutingKeys,
+            "recipientKeys": [["#key-2"]]   // peerdid-swift encodes key-agreement key first.
+        ] as AnyCodable
         return try PeerDIDHelper.createAlgo2(
             authenticationKeys: [authKey],
             agreementKeys: [agreementKey],
-            services: [service],
-            recipientKeys: [["#key-2"]])    // peerdid-swift encodes key-agreement key first.
+            services: [service])
             .string
     }
 

--- a/Sources/AriesFramework/connection/handlers/DidExchangeCompleteHandler.swift
+++ b/Sources/AriesFramework/connection/handlers/DidExchangeCompleteHandler.swift
@@ -1,0 +1,18 @@
+
+import Foundation
+
+class DidExchangeCompleteHandler: MessageHandler {
+    let agent: Agent
+    let messageType = DidExchangeCompleteMessage.type
+
+    init(agent: Agent) {
+        self.agent = agent
+    }
+
+    func handle(messageContext: InboundMessageContext) async throws -> OutboundMessage? {
+        if var connection = messageContext.connection, connection.state == .Responded {
+            try await agent.connectionService.updateState(connectionRecord: &connection, newState: .Complete)
+        }
+        return nil
+    }
+}

--- a/Sources/AriesFramework/connection/handlers/DidExchangeRequestHandler.swift
+++ b/Sources/AriesFramework/connection/handlers/DidExchangeRequestHandler.swift
@@ -1,0 +1,20 @@
+
+import Foundation
+
+class DidExchangeRequestHandler: MessageHandler {
+    let agent: Agent
+    let messageType = DidExchangeRequestMessage.type
+
+    init(agent: Agent) {
+        self.agent = agent
+    }
+
+    func handle(messageContext: InboundMessageContext) async throws -> OutboundMessage? {
+        let connectionRecord = try await agent.didExchangeService.processRequest(messageContext: messageContext)
+        if connectionRecord.autoAcceptConnection ?? false || agent.agentConfig.autoAcceptConnections {
+            return try await agent.didExchangeService.createResponse(connectionId: connectionRecord.id)
+        }
+
+        return nil
+    }
+}

--- a/Sources/AriesFramework/connection/handlers/DidExchangeResponseHandler.swift
+++ b/Sources/AriesFramework/connection/handlers/DidExchangeResponseHandler.swift
@@ -1,0 +1,21 @@
+
+import Foundation
+
+class DidExchangeResponseHandler: MessageHandler {
+    let agent: Agent
+    let messageType = DidExchangeResponseMessage.type
+
+    init(agent: Agent) {
+        self.agent = agent
+    }
+
+    func handle(messageContext: InboundMessageContext) async throws -> OutboundMessage? {
+        let connection = try await agent.didExchangeService.processResponse(messageContext: messageContext)
+
+        if connection.autoAcceptConnection ?? agent.agentConfig.autoAcceptConnections {
+            return try await agent.didExchangeService.createComplete(connectionId: connection.id)
+        }
+
+        return nil
+    }
+}

--- a/Sources/AriesFramework/connection/messages/DidExchangeCompleteMessage.swift
+++ b/Sources/AriesFramework/connection/messages/DidExchangeCompleteMessage.swift
@@ -1,0 +1,20 @@
+
+import Foundation
+
+public class DidExchangeCompleteMessage: AgentMessage {
+    public static var type: String = "https://didcomm.org/didexchange/1.0/complete"
+
+    public init(id: String? = nil, threadId: String, parentThreadId: String) {
+        super.init(id: id, type: DidExchangeCompleteMessage.type)
+
+        self.thread = ThreadDecorator(threadId: threadId, parentThreadId: parentThreadId)
+    }
+
+    public required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+    }
+
+    public override func encode(to encoder: Encoder) throws {
+        try super.encode(to: encoder)
+    }
+}

--- a/Sources/AriesFramework/connection/messages/DidExchangeCompleteMessage.swift
+++ b/Sources/AriesFramework/connection/messages/DidExchangeCompleteMessage.swift
@@ -2,7 +2,7 @@
 import Foundation
 
 public class DidExchangeCompleteMessage: AgentMessage {
-    public static var type: String = "https://didcomm.org/didexchange/1.0/complete"
+    public static var type: String = "https://didcomm.org/didexchange/1.1/complete"
 
     public init(id: String? = nil, threadId: String, parentThreadId: String) {
         super.init(id: id, type: DidExchangeCompleteMessage.type)

--- a/Sources/AriesFramework/connection/messages/DidExchangeRequestMessage.swift
+++ b/Sources/AriesFramework/connection/messages/DidExchangeRequestMessage.swift
@@ -6,7 +6,7 @@ public class DidExchangeRequestMessage: AgentMessage {
     var goalCode: String?
     var goal: String?
     var did: String
-    public static var type: String = "https://didcomm.org/didexchange/1.0/request"
+    public static var type: String = "https://didcomm.org/didexchange/1.1/request"
 
     private enum CodingKeys: String, CodingKey {
         case label, goalCode = "goal_code", goal, did

--- a/Sources/AriesFramework/connection/messages/DidExchangeRequestMessage.swift
+++ b/Sources/AriesFramework/connection/messages/DidExchangeRequestMessage.swift
@@ -1,0 +1,40 @@
+
+import Foundation
+
+public class DidExchangeRequestMessage: AgentMessage {
+    var label: String
+    var goalCode: String?
+    var goal: String?
+    var did: String
+    public static var type: String = "https://didcomm.org/didexchange/1.0/request"
+
+    private enum CodingKeys: String, CodingKey {
+        case label, goalCode = "goal_code", goal, did
+    }
+
+    public init(id: String, label: String, goalCode: String?, goal: String?, did: String) {
+        self.label = label
+        self.goalCode = goalCode
+        self.goal = goal
+        self.did = did
+        super.init(id: id, type: DidExchangeRequestMessage.type)
+    }
+
+    public required init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        label = try values.decode(String.self, forKey: .label)
+        goalCode = try values.decodeIfPresent(String.self, forKey: .goalCode)
+        goal = try values.decodeIfPresent(String.self, forKey: .goal)
+        did = try values.decode(String.self, forKey: .did)
+        try super.init(from: decoder)
+    }
+
+    public override func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(label, forKey: .label)
+        try container.encodeIfPresent(goalCode, forKey: .goalCode)
+        try container.encodeIfPresent(goal, forKey: .goal)
+        try container.encode(did, forKey: .did)
+        try super.encode(to: encoder)
+    }
+}

--- a/Sources/AriesFramework/connection/messages/DidExchangeRequestMessage.swift
+++ b/Sources/AriesFramework/connection/messages/DidExchangeRequestMessage.swift
@@ -12,7 +12,7 @@ public class DidExchangeRequestMessage: AgentMessage {
         case label, goalCode = "goal_code", goal, did
     }
 
-    public init(id: String, label: String, goalCode: String?, goal: String?, did: String) {
+    public init(id: String? = nil, label: String, goalCode: String? = nil, goal: String? = nil, did: String) {
         self.label = label
         self.goalCode = goalCode
         self.goal = goal

--- a/Sources/AriesFramework/connection/messages/DidExchangeResponseMessage.swift
+++ b/Sources/AriesFramework/connection/messages/DidExchangeResponseMessage.swift
@@ -4,15 +4,17 @@ import Foundation
 public class DidExchangeResponseMessage: AgentMessage {
     var did: String
     var didDoc: Attachment?
-    public static var type: String = "https://didcomm.org/didexchange/1.0/response"
+    var didRotate: Attachment?
+    public static var type: String = "https://didcomm.org/didexchange/1.1/response"
 
     private enum CodingKeys: String, CodingKey {
-        case did, didDoc = "did_doc~attach"
+        case did, didDoc = "did_doc~attach", didRotate = "did_rotate~attach"
     }
 
-    public init(id: String? = nil, threadId: String, did: String, didDoc: Attachment?) {
+    public init(id: String? = nil, threadId: String, did: String, didDoc: Attachment? = nil, didRotate: Attachment? = nil) {
         self.did = did
         self.didDoc = didDoc
+        self.didRotate = didRotate
         super.init(id: id, type: DidExchangeResponseMessage.type)
 
         self.thread = ThreadDecorator(threadId: threadId)
@@ -22,6 +24,7 @@ public class DidExchangeResponseMessage: AgentMessage {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         did = try values.decode(String.self, forKey: .did)
         didDoc = try values.decodeIfPresent(Attachment.self, forKey: .didDoc)
+        didRotate = try values.decodeIfPresent(Attachment.self, forKey: .didRotate)
         try super.init(from: decoder)
     }
 
@@ -29,6 +32,7 @@ public class DidExchangeResponseMessage: AgentMessage {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(did, forKey: .did)
         try container.encodeIfPresent(didDoc, forKey: .didDoc)
+        try container.encodeIfPresent(didRotate, forKey: .didRotate)
         try super.encode(to: encoder)
     }
 }

--- a/Sources/AriesFramework/connection/messages/DidExchangeResponseMessage.swift
+++ b/Sources/AriesFramework/connection/messages/DidExchangeResponseMessage.swift
@@ -1,0 +1,34 @@
+
+import Foundation
+
+public class DidExchangeResponseMessage: AgentMessage {
+    var did: String
+    var didDoc: Attachment?
+    public static var type: String = "https://didcomm.org/didexchange/1.0/response"
+
+    private enum CodingKeys: String, CodingKey {
+        case did, didDoc = "did_doc~attach"
+    }
+
+    public init(id: String? = nil, threadId: String, did: String, didDoc: Attachment?) {
+        self.did = did
+        self.didDoc = didDoc
+        super.init(id: id, type: DidExchangeResponseMessage.type)
+
+        self.thread = ThreadDecorator(threadId: threadId)
+    }
+
+    public required init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        did = try values.decode(String.self, forKey: .did)
+        didDoc = try values.decodeIfPresent(Attachment.self, forKey: .didDoc)
+        try super.init(from: decoder)
+    }
+
+    public override func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(did, forKey: .did)
+        try container.encodeIfPresent(didDoc, forKey: .didDoc)
+        try super.encode(to: encoder)
+    }
+}

--- a/Sources/AriesFramework/connection/models/didauth/DidCommV2Service.swift
+++ b/Sources/AriesFramework/connection/models/didauth/DidCommV2Service.swift
@@ -1,0 +1,15 @@
+
+import Foundation
+
+public struct DidCommV2Service: Codable {
+    static var type: String = "DIDCommMessaging"
+    var type: String = DidCommV2Service.type
+    var id: String
+    var serviceEndpoint: ServiceEndpoint
+
+    public struct ServiceEndpoint: Codable {
+        var uri: String
+        var routingKeys: [String]?
+        var accept: [String]?
+    }
+}

--- a/Sources/AriesFramework/connection/models/didauth/DidDoc.swift
+++ b/Sources/AriesFramework/connection/models/didauth/DidDoc.swift
@@ -64,7 +64,7 @@ extension DidDoc {
         service = try didDocument.services?.map { service -> DidDocService in
             guard let endpoint: Dictionary<AnyHashable, Any> = service.serviceEndpoint.get(),
                 let endpointUri = endpoint["uri"] as? String,
-                let routingKeys = endpoint["routing_keys"] as? [String] else {
+                let routingKeys = endpoint["routingKeys"] as? [String] else {
                 throw AriesFrameworkError.frameworkError("Service endpoint cannot be decoded")
             }
             let parsedRoutingKeys = try routingKeys.map { try DIDParser.ConvertDIDToVerkey(did: $0) }

--- a/Sources/AriesFramework/connection/models/didauth/DidDoc.swift
+++ b/Sources/AriesFramework/connection/models/didauth/DidDoc.swift
@@ -61,7 +61,7 @@ extension DidDoc {
             controller: id,
             publicKeyBase58: recipientKey)]
         authentication = [Authentication.referenced(ReferencedAuthentication(type: publicKey[0].type, publicKey: publicKey[0].id))]
-        service = try didDocument.services?.compactMap { service -> DidDocService? in
+        service = try didDocument.services?.map { service -> DidDocService in
             guard let endpoint: Dictionary<AnyHashable, Any> = service.serviceEndpoint.get(),
                 let endpointUri = endpoint["uri"] as? String,
                 let routingKeys = endpoint["routing_keys"] as? [String] else {
@@ -74,6 +74,16 @@ extension DidDoc {
                 recipientKeys: [recipientKey],
                 routingKeys: parsedRoutingKeys))
         } ?? []
+
+        if service.isEmpty {
+            service = [
+                DidDocService.didComm(DidCommService(
+                    id: "#IndyAgentService",
+                    serviceEndpoint: DID_COMM_TRANSPORT_QUEUE,
+                    recipientKeys: [recipientKey],
+                    routingKeys: []))
+            ]
+        }
     }
 
     func publicKey(id: String) -> PublicKey? {

--- a/Sources/AriesFramework/connection/models/didauth/DidDoc.swift
+++ b/Sources/AriesFramework/connection/models/didauth/DidDoc.swift
@@ -61,16 +61,17 @@ extension DidDoc {
             controller: id,
             publicKeyBase58: recipientKey)]
         authentication = [Authentication.referenced(ReferencedAuthentication(type: publicKey[0].type, publicKey: publicKey[0].id))]
-        service = try didDocument.services?.map { service -> DidDocService in
-            guard let endpoint: [AnyHashable: Any] = service.serviceEndpoint.get(),
-                let endpointUri = endpoint["uri"] as? String,
-                let routingKeys = endpoint["routingKeys"] as? [String] else {
-                throw AriesFrameworkError.frameworkError("Service endpoint cannot be decoded")
+        service = try didDocument.services?.map { serviceItem -> DidDocService in
+            guard let service = serviceItem.value as? [String: Any],
+                let serviceId = service["id"] as? String,
+                let endpoint = service["serviceEndpoint"] as? String,
+                let routingKeys = service["routingKeys"] as? [String] else {
+                throw AriesFrameworkError.frameworkError("Service cannot be decoded")
             }
             let parsedRoutingKeys = try routingKeys.map { try DIDParser.ConvertDIDToVerkey(did: $0) }
             return DidDocService.didComm(DidCommService(
-                id: service.id,
-                serviceEndpoint: endpointUri,
+                id: serviceId,
+                serviceEndpoint: endpoint,
                 recipientKeys: [recipientKey],
                 routingKeys: parsedRoutingKeys))
         } ?? []

--- a/Sources/AriesFramework/connection/models/didauth/DidDoc.swift
+++ b/Sources/AriesFramework/connection/models/didauth/DidDoc.swift
@@ -62,7 +62,7 @@ extension DidDoc {
             publicKeyBase58: recipientKey)]
         authentication = [Authentication.referenced(ReferencedAuthentication(type: publicKey[0].type, publicKey: publicKey[0].id))]
         service = try didDocument.services?.map { service -> DidDocService in
-            guard let endpoint: Dictionary<AnyHashable, Any> = service.serviceEndpoint.get(),
+            guard let endpoint: [AnyHashable: Any] = service.serviceEndpoint.get(),
                 let endpointUri = endpoint["uri"] as? String,
                 let routingKeys = endpoint["routingKeys"] as? [String] else {
                 throw AriesFrameworkError.frameworkError("Service endpoint cannot be decoded")

--- a/Sources/AriesFramework/connection/models/didauth/DidDocService.swift
+++ b/Sources/AriesFramework/connection/models/didauth/DidDocService.swift
@@ -5,10 +5,11 @@ public enum DidDocService: Codable {
     case didDocument(DidDocumentService)
     case didComm(DidCommService)
     case indyAgent(IndyAgentService)
+    case didCommV2(DidCommV2Service)
 
     var priority: Int {
         switch self {
-        case .didDocument:
+        case .didDocument, .didCommV2:
             return 0
         case .didComm(let doc):
             return doc.priority ?? 0
@@ -25,12 +26,14 @@ public enum DidDocService: Codable {
             return doc.type
         case .indyAgent(let doc):
             return doc.type
+        case .didCommV2(let doc):
+            return doc.type
         }
     }
 
     var recipientKeys: [String] {
         switch self {
-        case .didDocument:
+        case .didDocument, .didCommV2:
             return []
         case .didComm(let doc):
             return doc.recipientKeys
@@ -47,6 +50,8 @@ public enum DidDocService: Codable {
             return doc.serviceEndpoint
         case .indyAgent(let doc):
             return doc.serviceEndpoint
+        case .didCommV2(let doc):
+            return doc.serviceEndpoint.uri
         }
     }
 
@@ -58,6 +63,8 @@ public enum DidDocService: Codable {
             return doc.routingKeys
         case .indyAgent(let doc):
             return doc.routingKeys
+        case .didCommV2(let doc):
+            return doc.serviceEndpoint.routingKeys
         }
     }
 
@@ -73,6 +80,8 @@ public enum DidDocService: Codable {
             self = .didComm(try DidCommService(from: decoder))
         case IndyAgentService.type:
             self = .indyAgent(try IndyAgentService(from: decoder))
+        case DidCommV2Service.type:
+            self = .didCommV2(try DidCommV2Service(from: decoder))
         default:
             self = .didDocument(try DidDocumentService(from: decoder))
         }
@@ -86,6 +95,8 @@ public enum DidDocService: Codable {
             try didComm.encode(to: encoder)
         case .indyAgent(let indyAgent):
             try indyAgent.encode(to: encoder)
+        case .didCommV2(let didCommV2):
+            try didCommV2.encode(to: encoder)
         }
     }
 }

--- a/Sources/AriesFramework/connection/models/didauth/ServiceEndpoint.swift
+++ b/Sources/AriesFramework/connection/models/didauth/ServiceEndpoint.swift
@@ -1,0 +1,8 @@
+
+import Foundation
+
+public struct ServiceEndpoint: Codable {
+    var uri: String
+    var accept: [String]
+    var routingKeys: [String]
+}

--- a/Sources/AriesFramework/connection/models/didauth/ServiceEndpoint.swift
+++ b/Sources/AriesFramework/connection/models/didauth/ServiceEndpoint.swift
@@ -1,8 +1,0 @@
-
-import Foundation
-
-public struct ServiceEndpoint: Codable {
-    var uri: String
-    var accept: [String]
-    var routingKeys: [String]
-}

--- a/Sources/AriesFramework/connection/repository/ConnectionRecord.swift
+++ b/Sources/AriesFramework/connection/repository/ConnectionRecord.swift
@@ -116,7 +116,10 @@ extension ConnectionRecord: Codable {
 
     func theirKey() -> String? {
         guard let service = theirDidDoc?.didCommServices().first else {
-            return nil
+            guard let publicKey = theirDidDoc?.publicKey.first else {
+                return nil
+            }
+            return publicKey.value
         }
 
         return service.recipientKeys.first

--- a/Sources/AriesFramework/oob/OutOfBandCommand.swift
+++ b/Sources/AriesFramework/oob/OutOfBandCommand.swift
@@ -357,10 +357,8 @@ public class OutOfBandCommand {
             supportedProtocols.contains(agent.agentConfig.preferredHandshakeProtocol) {
             return agent.agentConfig.preferredHandshakeProtocol
         }
-        for protocolName in handshakeProtocols {
-            if supportedProtocols.contains(protocolName) {
-                return protocolName
-            }
+        for protocolName in handshakeProtocols where supportedProtocols.contains(protocolName) {
+            return protocolName
         }
         throw AriesFrameworkError.frameworkError(
             "None of the provided handshake protocols [\(handshakeProtocols)] are supported. Supported protocols are [\(supportedProtocols)]"

--- a/Sources/AriesFramework/oob/OutOfBandCommand.swift
+++ b/Sources/AriesFramework/oob/OutOfBandCommand.swift
@@ -327,7 +327,7 @@ public class OutOfBandCommand {
     }
 
     private func getSupportedHandshakeProtocols() -> [HandshakeProtocol] {
-        return [.Connections, .DidExchange10]
+        return [.Connections, .DidExchange11]
     }
 
     private func assertHandshakeProtocols(_ handshakeProtocols: [HandshakeProtocol]) throws {

--- a/Sources/AriesFramework/oob/OutOfBandCommand.swift
+++ b/Sources/AriesFramework/oob/OutOfBandCommand.swift
@@ -250,13 +250,11 @@ public class OutOfBandCommand {
 
             if connectionRecord == nil {
                 logger.debug("Creating new connection.")
-                if !handshakeProtocols.contains(.Connections) {
-                    throw AriesFrameworkError.frameworkError(
-                        "Unsupported handshake protocol. Supported protocols: \(handshakeProtocols)"
-                    )
-                }
-
-                connectionRecord = try await agent.connections.acceptOutOfBandInvitation(outOfBandRecord: outOfBandRecord, config: config)
+                let handshakeProtocol = try selectHandshakeProtocol(handshakeProtocols)
+                connectionRecord = try await agent.connections.acceptOutOfBandInvitation(
+                    outOfBandRecord: outOfBandRecord,
+                    handshakeProtocol: handshakeProtocol,
+                    config: config)
             }
 
             if try await agent.connectionService.fetchState(connectionRecord: connectionRecord!) != .Complete {
@@ -328,9 +326,8 @@ public class OutOfBandCommand {
         return connections.first(where: { $0.isReady() })
     }
 
-    // Only Connection protocol is supported for now
     private func getSupportedHandshakeProtocols() -> [HandshakeProtocol] {
-        return [.Connections]
+        return [.Connections, .DidExchange10]
     }
 
     private func assertHandshakeProtocols(_ handshakeProtocols: [HandshakeProtocol]) throws {
@@ -347,5 +344,21 @@ public class OutOfBandCommand {
         return handshakeProtocols.allSatisfy({ (p) -> Bool in
             return supportedProtocols.contains(p)
         })
+    }
+
+    private func selectHandshakeProtocol(_ handshakeProtocols: [HandshakeProtocol]) throws -> HandshakeProtocol {
+        let supportedProtocols = getSupportedHandshakeProtocols()
+        if handshakeProtocols.contains(agent.agentConfig.preferredHandshakeProtocol) &&
+            supportedProtocols.contains(agent.agentConfig.preferredHandshakeProtocol) {
+            return agent.agentConfig.preferredHandshakeProtocol
+        }
+        for protocolName in handshakeProtocols {
+            if supportedProtocols.contains(protocolName) {
+                return protocolName
+            }
+        }
+        throw AriesFrameworkError.frameworkError(
+            "None of the provided handshake protocols [\(handshakeProtocols)] are supported. Supported protocols are [\(supportedProtocols)]"
+        )
     }
 }

--- a/Sources/AriesFramework/oob/util/DIDParser.swift
+++ b/Sources/AriesFramework/oob/util/DIDParser.swift
@@ -86,4 +86,9 @@ public class DIDParser {
         let verkey = bytes.dropFirst(2)
         return Base58.base58Encode(Array(verkey))
     }
+
+    public static func ConvertDIDToVerkey(did: String) throws -> String {
+        //TODO: support did:peer
+        return try ConvertDidKeyToVerkey(did: did)
+    }
 }

--- a/Sources/AriesFramework/oob/util/DIDParser.swift
+++ b/Sources/AriesFramework/oob/util/DIDParser.swift
@@ -88,7 +88,7 @@ public class DIDParser {
     }
 
     public static func ConvertDIDToVerkey(did: String) throws -> String {
-        //TODO: support did:peer
+        // TODO: support did:peer
         return try ConvertDidKeyToVerkey(did: did)
     }
 }

--- a/Sources/AriesFramework/routing/MediationRecipient.swift
+++ b/Sources/AriesFramework/routing/MediationRecipient.swift
@@ -135,12 +135,17 @@ class MediationRecipient {
         try await pickupMessages(mediatorConnection: mediatorConnection)
     }
 
-    func getRouting() async throws -> Routing {
+    func getRoutingInfo() async throws -> ([String], [String]) {
         let mediator = try await repository.getDefault()
         let endpoints = mediator?.endpoint == nil ? agent.agentConfig.endpoints : [mediator!.endpoint!]
         let routingKeys = mediator?.routingKeys ?? []
+        return (endpoints, routingKeys)
+    }
 
+    func getRouting() async throws -> Routing {
+        let (endpoints, routingKeys) = try await getRoutingInfo()
         let (did, verkey) = try await agent.wallet.createDid()
+        let mediator = try await repository.getDefault()
         if mediator != nil && mediator!.isReady() {
             try await keylistUpdate(mediator: mediator!, verkey: verkey)
         }

--- a/Tests/AriesFrameworkTests/agent/AgentTest.swift
+++ b/Tests/AriesFrameworkTests/agent/AgentTest.swift
@@ -24,8 +24,8 @@ class AgentTest: XCTestCase {
     }
 
     override func tearDown() async throws {
-        try await super.tearDown()
         try await agent.reset()
+        try await super.tearDown()
     }
 
     func testMediatorConnect() async throws {

--- a/Tests/AriesFrameworkTests/agent/AgentTest.swift
+++ b/Tests/AriesFrameworkTests/agent/AgentTest.swift
@@ -151,6 +151,7 @@ class AgentTest: XCTestCase {
     // Run faber in AFJ/demo/ and run mediator in AFJ/samples before this test
     func testDemoFaber() async throws {
         var config = try TestHelper.getBcovinConfig(name: "alice")
+        config.preferredHandshakeProtocol = .DidExchange11
         config.mediatorConnectionsInvite = String(data: try Data(contentsOf: URL(string: mediatorInvitationUrl)!), encoding: .utf8)!
 
         let expectation = TestHelper.expectation(description: "credential received")
@@ -162,24 +163,6 @@ class AgentTest: XCTestCase {
         let invitation = try OutOfBandInvitation.fromUrl(faberInvitationUrl)
         print("Start connecting to faber")
         _ = try await agent.oob.receiveInvitation(invitation)
-
-        try await TestHelper.wait(for: expectation, timeout: 120)
-    }
-
-    // Run faber in AFJ/demo/ in legacy_connection branch
-    func testDemoFaberWithLegacyConnection() async throws {
-        let config = try TestHelper.getBcovinConfig(name: "alice")
-        let expectation = TestHelper.expectation(description: "credential received")
-        let testDelegate = CredentialDelegate(expectation: expectation)
-        agent = Agent(agentConfig: config, agentDelegate: testDelegate)
-        try await agent.initialize()
-
-        print("Getting invitation from faber")
-        let faberInvitationUrl = "http://localhost:9001/invitation"
-        let faberInvite = String(data: try Data(contentsOf: URL(string: faberInvitationUrl)!), encoding: .utf8)!
-        let invitation = try ConnectionInvitationMessage.fromUrl(faberInvite)
-        print("Start connecting to faber")
-        _ = try await agent.connections.receiveInvitation(invitation)
 
         try await TestHelper.wait(for: expectation, timeout: 120)
     }

--- a/Tests/AriesFrameworkTests/connection/DidExchangeTest.swift
+++ b/Tests/AriesFrameworkTests/connection/DidExchangeTest.swift
@@ -1,0 +1,52 @@
+
+import XCTest
+@testable import AriesFramework
+
+class DidExchangeTest: XCTestCase {
+    var faberAgent: Agent!
+    var aliceAgent: Agent!
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        let faberConfig = try TestHelper.getBaseConfig(name: "faber")
+        let aliceConfig = try TestHelper.getBaseConfig(name: "alice")
+
+        faberAgent = Agent(agentConfig: faberConfig, agentDelegate: nil)
+        aliceAgent = Agent(agentConfig: aliceConfig, agentDelegate: nil)
+
+        faberAgent.setOutboundTransport(SubjectOutboundTransport(subject: aliceAgent))
+        aliceAgent.setOutboundTransport(SubjectOutboundTransport(subject: faberAgent))
+
+        try await faberAgent.initialize()
+        try await aliceAgent.initialize()
+    }
+
+    override func tearDown() async throws {
+        try await faberAgent.reset()
+        try await aliceAgent.reset()
+        try await super.tearDown()
+    }
+
+    func testOobConnection() async throws {
+        let outOfBandRecord = try await faberAgent.oob.createInvitation(config: CreateOutOfBandInvitationConfig())
+        let invitation = outOfBandRecord.outOfBandInvitation
+
+        aliceAgent.agentConfig.preferredHandshakeProtocol = .DidExchange10
+        let (_, connection) = try await aliceAgent.oob.receiveInvitation(invitation)
+        guard let aliceFaberConnection = connection else {
+            XCTFail("Connection is nil after receiving invitation from url")
+            return
+        }
+        XCTAssertEqual(aliceFaberConnection.state, .Complete)
+
+        guard let faberAliceConnection = await faberAgent.connectionService.findByInvitationKey(try invitation.invitationKey()!) else {
+            XCTFail("Cannot find connection by invitation key")
+            return
+        }
+        XCTAssertEqual(faberAliceConnection.state, .Complete)
+
+        XCTAssertEqual(TestHelper.isConnectedWith(received: faberAliceConnection, connection: aliceFaberConnection), true)
+        XCTAssertEqual(TestHelper.isConnectedWith(received: aliceFaberConnection, connection: faberAliceConnection), true)
+    }
+}

--- a/Tests/AriesFrameworkTests/connection/DidExchangeTest.swift
+++ b/Tests/AriesFrameworkTests/connection/DidExchangeTest.swift
@@ -32,7 +32,7 @@ class DidExchangeTest: XCTestCase {
         let outOfBandRecord = try await faberAgent.oob.createInvitation(config: CreateOutOfBandInvitationConfig())
         let invitation = outOfBandRecord.outOfBandInvitation
 
-        aliceAgent.agentConfig.preferredHandshakeProtocol = .DidExchange10
+        aliceAgent.agentConfig.preferredHandshakeProtocol = .DidExchange11
         let (_, connection) = try await aliceAgent.oob.receiveInvitation(invitation)
         guard let aliceFaberConnection = connection else {
             XCTFail("Connection is nil after receiving invitation from url")

--- a/Tests/AriesFrameworkTests/connection/DidExchangeTest.swift
+++ b/Tests/AriesFrameworkTests/connection/DidExchangeTest.swift
@@ -44,7 +44,7 @@ class DidExchangeTest: XCTestCase {
         aliceAgent.agentConfig.preferredHandshakeProtocol = .DidExchange11
         let (_, connection) = try await aliceAgent.oob.receiveInvitation(invitation)
         guard let aliceFaberConnection = connection else {
-            XCTFail("Connection is nil after receiving invitation from url")
+            XCTFail("Connection is nil after receiving oob invitation")
             return
         }
         XCTAssertEqual(aliceFaberConnection.state, .Complete)

--- a/Tests/AriesFrameworkTests/connection/DidExchangeTest.swift
+++ b/Tests/AriesFrameworkTests/connection/DidExchangeTest.swift
@@ -12,8 +12,17 @@ class DidExchangeTest: XCTestCase {
         let faberConfig = try TestHelper.getBaseConfig(name: "faber")
         let aliceConfig = try TestHelper.getBaseConfig(name: "alice")
 
-        faberAgent = Agent(agentConfig: faberConfig, agentDelegate: nil)
-        aliceAgent = Agent(agentConfig: aliceConfig, agentDelegate: nil)
+        class TestDelegate: AgentDelegate {
+            let name: String
+            init(name: String) {
+                self.name = name
+            }
+            func onConnectionStateChanged(connectionRecord: ConnectionRecord) {
+                print("\(name): connection state changed to \(connectionRecord.state)")
+            }
+        }
+        faberAgent = Agent(agentConfig: faberConfig, agentDelegate: TestDelegate(name: "faber"))
+        aliceAgent = Agent(agentConfig: aliceConfig, agentDelegate: TestDelegate(name: "alice"))
 
         faberAgent.setOutboundTransport(SubjectOutboundTransport(subject: aliceAgent))
         aliceAgent.setOutboundTransport(SubjectOutboundTransport(subject: faberAgent))

--- a/Tests/AriesFrameworkTests/connection/DidExchangeTest.swift
+++ b/Tests/AriesFrameworkTests/connection/DidExchangeTest.swift
@@ -55,7 +55,7 @@ class DidExchangeTest: XCTestCase {
         }
         XCTAssertEqual(faberAliceConnection.state, .Complete)
 
-        XCTAssertEqual(TestHelper.isConnectedWith(received: faberAliceConnection, connection: aliceFaberConnection), true)
-        XCTAssertEqual(TestHelper.isConnectedWith(received: aliceFaberConnection, connection: faberAliceConnection), true)
+        XCTAssertTrue(TestHelper.isConnectedWith(received: faberAliceConnection, connection: aliceFaberConnection))
+        XCTAssertTrue(TestHelper.isConnectedWith(received: aliceFaberConnection, connection: faberAliceConnection))
     }
 }

--- a/Tests/AriesFrameworkTests/connection/PeerDIDServiceTest.swift
+++ b/Tests/AriesFrameworkTests/connection/PeerDIDServiceTest.swift
@@ -11,33 +11,8 @@ class PeerDIDServiceTest: XCTestCase {
         try await super.tearDown()
     }
 
-    func testPeerDIDnumAlgo0() async throws {
-        let config = try TestHelper.getBaseConfig(name: "alice")
-        agent = Agent(agentConfig: config, agentDelegate: nil)
-        try await agent.initialize()
-
-        let peerDID = try await agent.peerDIDService.createPeerDID(verkey: verkey)
-        XCTAssertTrue(peerDID.starts(with: "did:peer:0"))
-        let key1 = peerDID.dropFirst(10)
-
-        let didKey = try DIDParser.ConvertVerkeyToDidKey(verkey: verkey)
-        XCTAssertTrue(didKey.starts(with: "did:key:"))
-        let key2 = didKey.dropFirst(8)
-
-        XCTAssertEqual(key1, key2)
-
-        let didDoc = try agent.peerDIDService.parsePeerDID(peerDID)
-        XCTAssertEqual(didDoc.id, peerDID)
-        XCTAssertEqual(didDoc.publicKey.count, 1)
-        XCTAssertEqual(didDoc.service.count, 1)
-        XCTAssertEqual(didDoc.authentication.count, 1)
-        XCTAssertEqual(didDoc.publicKey[0].value, verkey)
-    }
-
     func testPeerDIDnumAlgo2() async throws {
-        var config = try TestHelper.getBaseConfig(name: "alice")
-        config.mediatorConnectionsInvite = "http://mediator.example.com/connections"
-        config.useMediator = false
+        let config = try TestHelper.getBaseConfig(name: "alice")
         agent = Agent(agentConfig: config, agentDelegate: nil)
         try await agent.initialize()
 
@@ -62,8 +37,6 @@ class PeerDIDServiceTest: XCTestCase {
         XCTAssertEqual(didCommService.recipientKeys.count, 1)
         XCTAssertEqual(didCommService.recipientKeys[0], verkey)
         XCTAssertEqual(didCommService.routingKeys?.count, 0)
-        // XCTAssertEqual(didCommService.serviceEndpoint, config.mediatorConnectionsInvite)
-        // The above should be true, but the service endpoint is not set in the test with config.useMediator = false
         XCTAssertEqual(didCommService.serviceEndpoint, agent.agentConfig.endpoints[0])
     }
 }

--- a/Tests/AriesFrameworkTests/connection/PeerDIDServiceTest.swift
+++ b/Tests/AriesFrameworkTests/connection/PeerDIDServiceTest.swift
@@ -29,7 +29,7 @@ class PeerDIDServiceTest: XCTestCase {
         let didDoc = try agent.peerDIDService.parsePeerDID(peerDID)
         XCTAssertEqual(didDoc.id, peerDID)
         XCTAssertEqual(didDoc.publicKey.count, 1)
-        XCTAssertEqual(didDoc.service.count, 0)
+        XCTAssertEqual(didDoc.service.count, 1)
         XCTAssertEqual(didDoc.authentication.count, 1)
         XCTAssertEqual(didDoc.publicKey[0].value, verkey)
     }

--- a/Tests/AriesFrameworkTests/connection/PeerDIDServiceTest.swift
+++ b/Tests/AriesFrameworkTests/connection/PeerDIDServiceTest.swift
@@ -1,0 +1,69 @@
+
+import XCTest
+@testable import AriesFramework
+
+class PeerDIDServiceTest: XCTestCase {
+    var agent: Agent!
+    let verkey = "3uhKmLCRYfe5YWDsgBC4VNTKk3RbnFCzgjVH3zmSKHWa"
+
+    override func tearDown() async throws {
+        try await agent.reset()
+        try await super.tearDown()
+    }
+
+    func testPeerDIDnumAlgo0() async throws {
+        let config = try TestHelper.getBaseConfig(name: "alice")
+        agent = Agent(agentConfig: config, agentDelegate: nil)
+        try await agent.initialize()
+
+        let peerDID = try await agent.peerDIDService.createPeerDID(verkey: verkey)
+        XCTAssertTrue(peerDID.starts(with: "did:peer:0"))
+        let key1 = peerDID.dropFirst(10)
+
+        let didKey = try DIDParser.ConvertVerkeyToDidKey(verkey: verkey)
+        XCTAssertTrue(didKey.starts(with: "did:key:"))
+        let key2 = didKey.dropFirst(8)
+
+        XCTAssertEqual(key1, key2)
+
+        let didDoc = try agent.peerDIDService.parsePeerDID(peerDID)
+        XCTAssertEqual(didDoc.id, peerDID)
+        XCTAssertEqual(didDoc.publicKey.count, 1)
+        XCTAssertEqual(didDoc.service.count, 0)
+        XCTAssertEqual(didDoc.authentication.count, 1)
+        XCTAssertEqual(didDoc.publicKey[0].value, verkey)
+    }
+
+    func testPeerDIDnumAlgo2() async throws {
+        var config = try TestHelper.getBaseConfig(name: "alice")
+        config.mediatorConnectionsInvite = "http://mediator.example.com/connections"
+        config.useMediator = false
+        agent = Agent(agentConfig: config, agentDelegate: nil)
+        try await agent.initialize()
+
+        let peerDID = try await agent.peerDIDService.createPeerDID(verkey: verkey)
+        XCTAssertTrue(peerDID.starts(with: "did:peer:2"))
+
+        let didDoc = try agent.peerDIDService.parsePeerDID(peerDID)
+        XCTAssertEqual(didDoc.id, peerDID)
+        XCTAssertEqual(didDoc.publicKey.count, 1)
+        XCTAssertEqual(didDoc.service.count, 1)
+        XCTAssertEqual(didDoc.authentication.count, 1)
+        XCTAssertEqual(didDoc.publicKey[0].value, verkey)
+
+        guard let service = didDoc.service.first else {
+            XCTFail("No service found")
+            return
+        }
+        guard case let .didComm(didCommService) = service else {
+            XCTFail("Service is not a DIDComm service")
+            return
+        }
+        XCTAssertEqual(didCommService.recipientKeys.count, 1)
+        XCTAssertEqual(didCommService.recipientKeys[0], verkey)
+        XCTAssertEqual(didCommService.routingKeys?.count, 0)
+        // XCTAssertEqual(didCommService.serviceEndpoint, config.mediatorConnectionsInvite)
+        // The above should be true, but the service endpoint is not set in the test with config.useMediator = false
+        XCTAssertEqual(didCommService.serviceEndpoint, agent.agentConfig.endpoints[0])
+    }
+}

--- a/Tests/AriesFrameworkTests/connection/PeerDIDServiceTest.swift
+++ b/Tests/AriesFrameworkTests/connection/PeerDIDServiceTest.swift
@@ -6,17 +6,29 @@ class PeerDIDServiceTest: XCTestCase {
     var agent: Agent!
     let verkey = "3uhKmLCRYfe5YWDsgBC4VNTKk3RbnFCzgjVH3zmSKHWa"
 
+    override func setUp() async throws {
+        try await super.setUp()
+        let config = try TestHelper.getBaseConfig(name: "alice")
+        agent = Agent(agentConfig: config, agentDelegate: nil)
+        try await agent.initialize()
+    }
+
     override func tearDown() async throws {
         try await agent.reset()
         try await super.tearDown()
     }
 
-    func testPeerDIDnumAlgo2() async throws {
-        let config = try TestHelper.getBaseConfig(name: "alice")
-        agent = Agent(agentConfig: config, agentDelegate: nil)
-        try await agent.initialize()
-
+    func testPeerDIDwithLegacyService() async throws {
         let peerDID = try await agent.peerDIDService.createPeerDID(verkey: verkey)
+        try parsePeerDID(peerDID)
+    }
+
+    func testPeerDIDwithDidCommV2Service() async throws {
+        let peerDID = try await agent.peerDIDService.createPeerDID(verkey: verkey, useLegacyService: false)
+        try parsePeerDID(peerDID)
+    }
+
+    func parsePeerDID(_ peerDID: String) throws {
         XCTAssertTrue(peerDID.starts(with: "did:peer:2"))
 
         let didDoc = try agent.peerDIDService.parsePeerDID(peerDID)

--- a/Tests/AriesFrameworkTests/connection/didAuth/DidDocTest.swift
+++ b/Tests/AriesFrameworkTests/connection/didAuth/DidDocTest.swift
@@ -47,6 +47,18 @@ let diddoc = [
             "recipientKeys": ["DADEajsDSaksLng9h"],
             "routingKeys": ["DADEajsDSaksLng9h"],
             "priority": 10
+        ],
+        [
+            "id": "did:example:123456789abcdefghi#didcomm-1",
+            "type": "DIDCommMessaging",
+            "serviceEndpoint": [
+                "uri": "https://example.com/path",
+                "accept": [
+                    "didcomm/v2",
+                    "didcomm/aip2;env=rfc587"
+                ],
+                "routingKeys": ["did:example:somemediator#somekey"]
+            ]
         ]
     ],
     "authentication": [
@@ -85,10 +97,13 @@ class DidDocTest: XCTestCase {
             XCTFail("service 0 should be DidDocumentService")
         }
         if case .indyAgent = didDoc.service[1] {} else {
-            XCTFail("service 2 should be IndyAgentService")
+            XCTFail("service 1 should be IndyAgentService")
         }
         if case .didComm = didDoc.service[2] {} else {
-            XCTFail("service 1 should be DidCommService")
+            XCTFail("service 2 should be DidCommService")
+        }
+        if case .didCommV2 = didDoc.service[3] {} else {
+            XCTFail("service 3 should be DidCommV2Service")
         }
 
         if case .referenced = didDoc.authentication[0] {} else {
@@ -104,7 +119,7 @@ class DidDocTest: XCTestCase {
         XCTAssertEqual(clone.id, "did:sov:LjgpST2rjsoxYegQDRm7EL")
         XCTAssertEqual(clone.context, "https://w3id.org/did/v1")
         XCTAssertEqual(clone.publicKey.count, 3)
-        XCTAssertEqual(clone.service.count, 3)
+        XCTAssertEqual(clone.service.count, 4)
         XCTAssertEqual(clone.authentication.count, 2)
 
         XCTAssertEqual(clone.publicKey[0].id, "3")
@@ -141,6 +156,15 @@ class DidDocTest: XCTestCase {
             XCTAssertEqual(comm.priority, 10)
         } else {
             XCTFail("service 2 should be DidCommService")
+        }
+        if case .didCommV2(let service) = clone.service[3] {
+            XCTAssertEqual(service.id, "did:example:123456789abcdefghi#didcomm-1")
+            XCTAssertEqual(service.type, "DIDCommMessaging")
+            XCTAssertEqual(service.serviceEndpoint.uri, "https://example.com/path")
+            XCTAssertEqual(service.serviceEndpoint.accept, ["didcomm/v2", "didcomm/aip2;env=rfc587"])
+            XCTAssertEqual(service.serviceEndpoint.routingKeys, ["did:example:somemediator#somekey"])
+        } else {
+            XCTFail("service 3 should be DidCommV2Service")
         }
     }
 

--- a/Tests/AriesFrameworkTests/oob/OobTest.swift
+++ b/Tests/AriesFrameworkTests/oob/OobTest.swift
@@ -125,8 +125,8 @@ class OobTest: XCTestCase {
         XCTAssertEqual(faberAliceConnection.state, .Complete)
 
         XCTAssertEqual(faberAliceConnection.alias, makeConnectionConfig.alias)
-        XCTAssertEqual(TestHelper.isConnectedWith(received: faberAliceConnection, connection: aliceFaberConnection), true)
-        XCTAssertEqual(TestHelper.isConnectedWith(received: aliceFaberConnection, connection: faberAliceConnection), true)
+        XCTAssertTrue(TestHelper.isConnectedWith(received: faberAliceConnection, connection: aliceFaberConnection))
+        XCTAssertTrue(TestHelper.isConnectedWith(received: aliceFaberConnection, connection: faberAliceConnection))
     }
 
     func testCredentialOffer() async throws {


### PR DESCRIPTION
Close #93

This PR implements DID Exchange Protocol and has been tested with Credo-ts.
There are some notes:
- `AgentConfig.preferredHandshakeProtocol` is introduced. Connection protocol is the default option. 
- Uses numAlgo 2 for peer-did
- Uses DIDCommV1 service "did-communication" when creating a peer-did
- Uses didexchange/1.1 type messages, but does not verify did_rotate attachment jet. (TODO)
