### PR TITLE
BaseRecord support Identifiable protocol

### DIFF
--- a/Sources/AriesFramework/storage/BaseRecord.swift
+++ b/Sources/AriesFramework/storage/BaseRecord.swift
@@ -1,7 +1,7 @@
 
 import Foundation
 
-public protocol BaseRecord {
+public protocol BaseRecord: Identifiable {
     var id: String { get set }
     static var type: String { get }
     var tags: Tags? { get set }


### PR DESCRIPTION
Since BaseRecord has the hashable id property, it would be convenient to specify Identifiable protocol support.