### PR TITLE
Support connection-less issue-credential and present-proof

### DIFF
--- a/Sources/AriesFramework/Types.swift
+++ b/Sources/AriesFramework/Types.swift
@@ -63,7 +63,8 @@ public struct OutboundPackage: Codable {
 
 public struct OutboundMessage {
     var payload: AgentMessage
-    var connection: ConnectionRecord
+    var connection: ConnectionRecord? = nil
+    var outOfBand: OutOfBandRecord? = nil
 }
 
 public struct EncryptedMessage: Codable {
@@ -95,6 +96,7 @@ public struct InboundMessageContext {
     let connection: ConnectionRecord?
     let senderVerkey: String?
     let recipientVerkey: String?
+    let outOfBand: OutOfBandRecord?
 
     func assertReadyConnection() throws -> ConnectionRecord {
         if connection == nil {

--- a/Sources/AriesFramework/agent/MessageReceiver.swift
+++ b/Sources/AriesFramework/agent/MessageReceiver.swift
@@ -19,21 +19,23 @@ public class MessageReceiver {
                                                        plaintextMessage: decryptedMessage.plaintextMessage,
                                                        connection: connection,
                                                        senderVerkey: decryptedMessage.senderKey,
-                                                       recipientVerkey: decryptedMessage.recipientKey)
+                                                       recipientVerkey: decryptedMessage.recipientKey,
+                                                       outOfBand: nil)
             try await agent.dispatcher.dispatch(messageContext: messageContext)
         } catch {
             logger.error("failed to receive encrypted message: \(error)")
         }
     }
 
-    func receivePlaintextMessage(_ plaintextMessage: String, connection: ConnectionRecord) async throws {
+    func receivePlaintextMessage(_ plaintextMessage: String, connection: ConnectionRecord? = nil, outOfBand: OutOfBandRecord? = nil) async throws {
         do {
             let message = try MessageReceiver.decodeAgentMessage(plaintextMessage: plaintextMessage)
             let messageContext = InboundMessageContext(message: message,
                                                        plaintextMessage: plaintextMessage,
                                                        connection: connection,
                                                        senderVerkey: nil,
-                                                       recipientVerkey: nil)
+                                                       recipientVerkey: nil,
+                                                       outOfBand: outOfBand)
             try await agent.dispatcher.dispatch(messageContext: messageContext)
         } catch {
             logger.error("failed to receive plaintext message: \(error)")

--- a/Sources/AriesFramework/connection/ConnectionCommand.swift
+++ b/Sources/AriesFramework/connection/ConnectionCommand.swift
@@ -112,7 +112,7 @@ public class ConnectionCommand {
         logger.debug("Accept connection invitation")
         let message = try await agent.connectionService.createRequest(connectionId: connectionId, autoAcceptConnection: autoAcceptConnection)
         try await agent.messageSender.send(message: message)
-        return message.connection
+        return message.connection!
     }
 
     func acceptOutOfBandInvitation(
@@ -133,6 +133,6 @@ public class ConnectionCommand {
                 autoAcceptConnection: config?.autoAcceptConnection)
         }
         try await agent.messageSender.send(message: message)
-        return message.connection
+        return message.connection!
     }
 }

--- a/Sources/AriesFramework/credentials/CredentialsCommand.swift
+++ b/Sources/AriesFramework/credentials/CredentialsCommand.swift
@@ -59,9 +59,14 @@ public class CredentialsCommand {
     public func acceptOffer(options: AcceptOfferOptions) async throws -> CredentialExchangeRecord {
         let message = try await agent.credentialService.createRequest(options: options)
         let credentialRecord = try await agent.credentialExchangeRepository.getById(options.credentialRecordId)
-        let connection = try await agent.connectionRepository.getById(credentialRecord.connectionId)
-        try await agent.messageSender.send(message: OutboundMessage(payload: message, connection: connection))
-
+        if let connectionId = credentialRecord.connectionId {
+            let connection = try await agent.connectionRepository.getById(connectionId)
+            try await agent.messageSender.send(message: OutboundMessage(payload: message, connection: connection))
+        } else {
+            // connection-less credential exchange
+            let oobRecord = try await agent.outOfBandRepository.findByTags(credentialRecord.tags)
+            try await agent.messageSender.send(message: OutboundMessage(payload: message, outOfBand: oobRecord))
+        }
         return credentialRecord
     }
 
@@ -74,9 +79,14 @@ public class CredentialsCommand {
     public func declineOffer(credentialRecordId: String) async throws -> CredentialExchangeRecord {
         let message = try await agent.credentialService.createOfferDeclinedProblemReport(credentialRecordId: credentialRecordId)
         let credentialRecord = try await agent.credentialExchangeRepository.getById(credentialRecordId)
-        let connection = try await agent.connectionRepository.getById(credentialRecord.connectionId)
-        try await agent.messageSender.send(message: OutboundMessage(payload: message, connection: connection))
-
+        if let connectionId = credentialRecord.connectionId {
+            let connection = try await agent.connectionRepository.getById(connectionId)
+            try await agent.messageSender.send(message: OutboundMessage(payload: message, connection: connection))
+        } else {
+            // connection-less credential exchange
+            let oobRecord = try await agent.outOfBandRepository.findByTags(credentialRecord.tags)
+            try await agent.messageSender.send(message: OutboundMessage(payload: message, outOfBand: oobRecord))
+        }
         return credentialRecord
     }
 
@@ -90,7 +100,7 @@ public class CredentialsCommand {
     public func acceptRequest(options: AcceptRequestOptions) async throws -> CredentialExchangeRecord {
         let message = try await agent.credentialService.createCredential(options: options)
         let credentialRecord = try await agent.credentialExchangeRepository.getById(options.credentialRecordId)
-        let connection = try await agent.connectionRepository.getById(credentialRecord.connectionId)
+        let connection = try await agent.connectionRepository.getById(credentialRecord.connectionId!)
         try await agent.messageSender.send(message: OutboundMessage(payload: message, connection: connection))
 
         return credentialRecord
@@ -106,9 +116,14 @@ public class CredentialsCommand {
     public func acceptCredential(options: AcceptCredentialOptions) async throws -> CredentialExchangeRecord {
         let message = try await agent.credentialService.createAck(options: options)
         let credentialRecord = try await agent.credentialExchangeRepository.getById(options.credentialRecordId)
-        let connection = try await agent.connectionRepository.getById(credentialRecord.connectionId)
-        try await agent.messageSender.send(message: OutboundMessage(payload: message, connection: connection))
-
+        if let connectionId = credentialRecord.connectionId {
+            let connection = try await agent.connectionRepository.getById(connectionId)
+            try await agent.messageSender.send(message: OutboundMessage(payload: message, connection: connection))
+        } else {
+            // connection-less credential exchange
+            let oobRecord = try await agent.outOfBandRepository.findByTags(credentialRecord.tags)
+            try await agent.messageSender.send(message: OutboundMessage(payload: message, outOfBand: oobRecord))
+        }
         return credentialRecord
     }
 

--- a/Sources/AriesFramework/credentials/handlers/IssueCredentialHandler.swift
+++ b/Sources/AriesFramework/credentials/handlers/IssueCredentialHandler.swift
@@ -14,7 +14,13 @@ class IssueCredentialHandler: MessageHandler {
 
         if (credentialRecord.autoAcceptCredential != nil && credentialRecord.autoAcceptCredential! == .always) || agent.agentConfig.autoAcceptCredential == .always {
             let message = try await agent.credentialService.createAck(options: AcceptCredentialOptions(credentialRecordId: credentialRecord.id))
-            return OutboundMessage(payload: message, connection: messageContext.connection!)
+
+            var outOfBand = messageContext.outOfBand
+            if outOfBand == nil {
+                outOfBand = try await agent.outOfBandRepository.findByTags(credentialRecord.tags)
+            }
+            return OutboundMessage(payload: message, connection: messageContext.connection, outOfBand: outOfBand)
+
         }
 
         return nil

--- a/Sources/AriesFramework/credentials/handlers/OfferCredentialHandler.swift
+++ b/Sources/AriesFramework/credentials/handlers/OfferCredentialHandler.swift
@@ -14,7 +14,12 @@ class OfferCredentialHandler: MessageHandler {
 
         if (credentialRecord.autoAcceptCredential != nil && credentialRecord.autoAcceptCredential! == .always) || agent.agentConfig.autoAcceptCredential == .always {
             let message = try await agent.credentialService.createRequest(options: AcceptOfferOptions(credentialRecordId: credentialRecord.id))
-            return OutboundMessage(payload: message, connection: messageContext.connection!)
+            
+            var outOfBand = messageContext.outOfBand
+            if outOfBand == nil {
+                outOfBand = try await agent.outOfBandRepository.findByTags(credentialRecord.tags)
+            }
+            return OutboundMessage(payload: message, connection: messageContext.connection, outOfBand: outOfBand)
         }
 
         return nil

--- a/Sources/AriesFramework/credentials/repository/CredentialExchangeRecord.swift
+++ b/Sources/AriesFramework/credentials/repository/CredentialExchangeRecord.swift
@@ -12,7 +12,7 @@ public struct CredentialExchangeRecord: BaseRecord {
     public var updatedAt: Date?
     public var tags: Tags?
 
-    public var connectionId: String
+    public var connectionId: String?
     public var threadId: String
     public var state: CredentialState
     public var autoAcceptCredential: AutoAcceptCredential?
@@ -33,7 +33,7 @@ extension CredentialExchangeRecord: Codable {
 
     init(
         tags: Tags? = nil,
-        connectionId: String,
+        connectionId: String? = nil,
         threadId: String,
         state: CredentialState,
         autoAcceptCredential: AutoAcceptCredential? = nil,

--- a/Sources/AriesFramework/oob/OutOfBandCommand.swift
+++ b/Sources/AriesFramework/oob/OutOfBandCommand.swift
@@ -282,15 +282,14 @@ public class OutOfBandCommand {
             if existingConnection != nil {
                 try await processMessages(messages, connectionRecord: existingConnection!)
             } else {
-                // TODO: send message to the service endpoint
-                throw AriesFrameworkError.frameworkError("Cannot process request messages. No connection found.")
+                try await processMessages(messages, outOfBand: outOfBandRecord)
             }
         }
 
         return (outOfBandRecord, nil)
     }
 
-    private func processMessages(_ messages: [String], connectionRecord: ConnectionRecord) async throws {
+    private func processMessages(_ messages: [String], connectionRecord: ConnectionRecord? = nil, outOfBand: OutOfBandRecord? = nil) async throws {
         let message = messages.first(where: { message in
             guard let agentMessage = try? MessageReceiver.decodeAgentMessage(plaintextMessage: message) else {
                 logger.warning("Cannot decode agent message: \(message)")
@@ -303,7 +302,7 @@ public class OutOfBandCommand {
             throw AriesFrameworkError.frameworkError("There is no message in requests~attach supported by agent.")
         }
 
-        try await agent.messageReceiver.receivePlaintextMessage(message!, connection: connectionRecord)
+        try await agent.messageReceiver.receivePlaintextMessage(message!, connection: connectionRecord, outOfBand: outOfBand)
     }
 
     private func handleHandshakeReuse(outOfBandRecord: OutOfBandRecord, connectionRecord: ConnectionRecord) async throws -> Bool {

--- a/Sources/AriesFramework/oob/repository/OutOfBandRepository.swift
+++ b/Sources/AriesFramework/oob/repository/OutOfBandRepository.swift
@@ -13,4 +13,8 @@ class OutOfBandRepository: Repository<OutOfBandRecord> {
     func findByFingerprint(_ fingerprint: String) async throws -> OutOfBandRecord? {
         return try await findSingleByQuery("{\"recipientKeyFingerprints\": [\"\(fingerprint)\"]}")
     }
+
+    func findByTags(_ tags: Tags?) async throws -> OutOfBandRecord? {
+        return try await findById(tags?["oobId"])
+    }
 }

--- a/Sources/AriesFramework/proofs/handlers/RequestPresentationHandler.swift
+++ b/Sources/AriesFramework/proofs/handlers/RequestPresentationHandler.swift
@@ -24,6 +24,12 @@ class RequestPresentationHandler: MessageHandler {
         let requestedCredentials = try await agent.proofService.autoSelectCredentialsForProofRequest(retrievedCredentials: retrievedCredentials)
 
         let (message, _) = try await agent.proofService.createPresentation(proofRecord: record, requestedCredentials: requestedCredentials)
-        return OutboundMessage(payload: message, connection: messageContext.connection!)
+
+        var outOfBand = messageContext.outOfBand
+        if outOfBand == nil {
+            outOfBand = try await agent.outOfBandRepository.findByTags(record.tags)
+        }
+
+        return OutboundMessage(payload: message, connection: messageContext.connection, outOfBand: outOfBand)
     }
 }

--- a/Sources/AriesFramework/proofs/repository/ProofExchangeRecord.swift
+++ b/Sources/AriesFramework/proofs/repository/ProofExchangeRecord.swift
@@ -7,7 +7,7 @@ public struct ProofExchangeRecord: BaseRecord {
     public var updatedAt: Date?
     public var tags: Tags?
 
-    public var connectionId: String
+    public var connectionId: String?
     public var threadId: String
     public var isVerified: Bool?
     public var presentationId: String?
@@ -25,7 +25,7 @@ extension ProofExchangeRecord: Codable {
 
     init(
         tags: Tags? = nil,
-        connectionId: String,
+        connectionId: String? = nil,
         threadId: String,
         isVerified: Bool? = nil,
         presentationId: String? = nil,

--- a/Sources/AriesFramework/storage/Repository.swift
+++ b/Sources/AriesFramework/storage/Repository.swift
@@ -82,8 +82,8 @@ public class Repository<T: BaseRecord & Codable> {
         }
     }
 
-    public func findById(_ id: String) async throws -> T? {
-        guard let record = try await wallet.session!.fetch(category: T.type, name: id, forUpdate: false) else {
+    public func findById(_ id: String?) async throws -> T? {
+        guard let id = id, let record = try await wallet.session!.fetch(category: T.type, name: id, forUpdate: false) else {
             return nil
         }
         return try recordToInstance(record: record)


### PR DESCRIPTION
To solve the issue #108 If Agent receives out-of-band message with attachment without handshake protocols, It precess the attachment and send message to counter party if necessary. When It send a message, It use the service decorator in the out-of-band message. By doing this Agent supports connection-less present-proof.

**WARNING**
This is not recomended to merge.
Just sharing the main concept. unit test is not implemented yet.