### PR TITLE
Disable non_optional_string_data_conversion lint rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -16,3 +16,4 @@ disabled_rules:
   - large_tuple
   - blanket_disable_command
   - unneeded_override
+  - non_optional_string_data_conversion

--- a/Tests/AriesFrameworkTests/connection-less/ConnectionlessExchangeTest.swift
+++ b/Tests/AriesFrameworkTests/connection-less/ConnectionlessExchangeTest.swift
@@ -1,4 +1,3 @@
-// swiftlint:disable force_cast
 
 import XCTest
 @testable import AriesFramework


### PR DESCRIPTION
`non_optional_string_data_conversion` has been added to swiftlint as of version `0.55`.
It does not seem to be necessary.