### PR TITLE
Ignore only the key duplication error when creating a DID.

### DIFF
--- a/Sources/AriesFramework/wallet/Wallet.swift
+++ b/Sources/AriesFramework/wallet/Wallet.swift
@@ -131,8 +131,12 @@ public class Wallet {
         let did = Base58.base58Encode([UInt8](publicKey[0..<16]))
         do {
             try await session!.insertKey(name: verkey, key: key, metadata: nil, tags: nil, expiryMs: nil)
-        } catch {
-            logger.error("createDid: Ignoring error. Failed to insert key: \(error)")
+        } catch let error as Askar.ErrorCode {
+            if error == .Duplicate(message: "Duplicate entry") {
+                logger.error("createDid: Ignoring error since key already exists. verkey=\(verkey)")
+            } else {
+                throw error
+            }
         }
         logger.debug("Created DID \(did) with verkey \(verkey)")
 

--- a/Sources/AriesFramework/wallet/Wallet.swift
+++ b/Sources/AriesFramework/wallet/Wallet.swift
@@ -131,12 +131,8 @@ public class Wallet {
         let did = Base58.base58Encode([UInt8](publicKey[0..<16]))
         do {
             try await session!.insertKey(name: verkey, key: key, metadata: nil, tags: nil, expiryMs: nil)
-        } catch let error as Askar.ErrorCode {
-            if error == .Duplicate(message: "Duplicate entry") {
-                logger.error("createDid: Ignoring error since key already exists. verkey=\(verkey)")
-            } else {
-                throw error
-            }
+        } catch ErrorCode.Duplicate(_) {
+            logger.error("createDid: Ignoring error since key already exists. verkey=\(verkey)")
         }
         logger.debug("Created DID \(did) with verkey \(verkey)")
 

--- a/Tests/AriesFrameworkTests/WalletTest.swift
+++ b/Tests/AriesFrameworkTests/WalletTest.swift
@@ -32,7 +32,7 @@ class WalletTest: XCTestCase {
         let (_, _) = try await agent.wallet.createDid(seed: "00000000000000000000000000000My1")
         let (_, _) = try await agent.wallet.createDid(seed: "00000000000000000000000000000My1")
     }
-    
+
     func testPackUnpack() async throws {
         let json = """
           {

--- a/Tests/AriesFrameworkTests/WalletTest.swift
+++ b/Tests/AriesFrameworkTests/WalletTest.swift
@@ -28,6 +28,11 @@ class WalletTest: XCTestCase {
         XCTAssertNil(wallet.session)
     }
 
+    func testIfTheDuplicateErrorIsIgnoredWhenCreatingDID() async throws {
+        let (_, _) = try await agent.wallet.createDid(seed: "00000000000000000000000000000My1")
+        let (_, _) = try await agent.wallet.createDid(seed: "00000000000000000000000000000My1")
+    }
+    
     func testPackUnpack() async throws {
         let json = """
           {


### PR DESCRIPTION
Ignore only the key duplication error when creating a DID. When inserting a randomly generated key when seed is not given, errors other than duplicate errors are likely to occur and should not be ignored.